### PR TITLE
⚡ Bolt: optimize LineCard schedule calculation

### DIFF
--- a/app/src/components/LineCard.tsx
+++ b/app/src/components/LineCard.tsx
@@ -55,13 +55,6 @@ export const detailsButtonVariants = tv({
 // TYPES
 // ============================================================================
 
-interface ScheduleResult {
-  nextSchedule: string;
-  previousSchedule: string;
-  status: string;
-  statusType: LineStatusType;
-}
-
 export interface LineCardProps
   extends
     Omit<ComponentProps<"article">, "onClick">,
@@ -74,70 +67,6 @@ export interface LineCardProps
   onDetailsClick: () => void;
   /** Se o card está selecionado */
   isSelected?: boolean;
-}
-
-// ============================================================================
-// HELPERS
-// ============================================================================
-
-/**
- * Calcula os horários de próximo ônibus e último que partiu
- */
-function calculateSchedules(horarios: string[]): ScheduleResult {
-  if (!horarios || horarios.length === 0) {
-    return {
-      nextSchedule: "--:--",
-      previousSchedule: "--:--",
-      status: "Sem Horários",
-      statusType: "closed",
-    };
-  }
-
-  const now = new Date();
-  const currentMinutes = now.getHours() * 60 + now.getMinutes();
-
-  const schedulesInMinutes = horarios
-    .filter((time) => time && time.includes(":"))
-    .map(timeToMinutes)
-    .sort((a, b) => a - b);
-
-  if (schedulesInMinutes.length === 0) {
-    return {
-      nextSchedule: "--:--",
-      previousSchedule: "--:--",
-      status: "Sem Horários",
-      statusType: "closed",
-    };
-  }
-
-  let nextSchedule = "--:--";
-  let previousSchedule = "--:--";
-  let status = "Encerrado";
-  let statusType: LineStatusType = "closed";
-
-  // Próximo horário
-  const next = schedulesInMinutes.find((schedule) => schedule > currentMinutes);
-  if (next !== undefined) {
-    nextSchedule = minutesToTime(next);
-    const diffMinutes = next - currentMinutes;
-    if (diffMinutes <= 15) {
-      status = `Próximo às ${nextSchedule}`;
-      statusType = "upcoming";
-    } else {
-      status = "Circulando";
-      statusType = "running";
-    }
-  }
-
-  // Último que partiu
-  const previousSchedules = schedulesInMinutes.filter(
-    (schedule) => schedule <= currentMinutes,
-  );
-  if (previousSchedules.length > 0) {
-    previousSchedule = minutesToTime(Math.max(...previousSchedules));
-  }
-
-  return { nextSchedule, previousSchedule, status, statusType };
 }
 
 // ============================================================================
@@ -242,8 +171,22 @@ export function LineCard({
   const shouldDisableSchedules =
     isInVacationPeriod && (!isVacationLine || isWeekend);
 
-  // Calcular horários
-  const { nextSchedule, previousSchedule, status, statusType } = useMemo(() => {
+  /**
+   * Performance Optimization: Memoize parsing of schedules.
+   * Only re-calculate if the schedule list changes.
+   * Sorting is included to be safe, although data is likely sorted.
+   */
+  const schedulesInMinutes = useMemo(() => {
+    if (!linha.horarios || linha.horarios.length === 0) return [];
+    return linha.horarios
+      .filter((time) => time && time.includes(":"))
+      .map(timeToMinutes)
+      .sort((a, b) => a - b);
+  }, [linha.horarios]);
+
+  // Calculate status/next/prev on every render to ensure freshness
+  // This is cheap (O(N) on small array) but ensures "currentMinutes" is always up to date
+  const { nextSchedule, previousSchedule, status, statusType } = (() => {
     if (shouldDisableSchedules) {
       return {
         nextSchedule: "Indisponível",
@@ -252,8 +195,48 @@ export function LineCard({
         statusType: "notRunning" as LineStatusType,
       };
     }
-    return calculateSchedules(linha.horarios);
-  }, [linha.horarios, shouldDisableSchedules]);
+
+    if (schedulesInMinutes.length === 0) {
+      return {
+        nextSchedule: "--:--",
+        previousSchedule: "--:--",
+        status: "Sem Horários",
+        statusType: "closed" as LineStatusType,
+      };
+    }
+
+    const now = new Date();
+    const currentMinutes = now.getHours() * 60 + now.getMinutes();
+
+    let nextSchedule = "--:--";
+    let previousSchedule = "--:--";
+    let status = "Encerrado";
+    let statusType: LineStatusType = "closed";
+
+    // Próximo horário
+    const next = schedulesInMinutes.find((schedule) => schedule > currentMinutes);
+    if (next !== undefined) {
+      nextSchedule = minutesToTime(next);
+      const diffMinutes = next - currentMinutes;
+      if (diffMinutes <= 15) {
+        status = `Próximo às ${nextSchedule}`;
+        statusType = "upcoming";
+      } else {
+        status = "Circulando";
+        statusType = "running";
+      }
+    }
+
+    // Último que partiu
+    const previousSchedules = schedulesInMinutes.filter(
+      (schedule) => schedule <= currentMinutes,
+    );
+    if (previousSchedules.length > 0) {
+      previousSchedule = minutesToTime(Math.max(...previousSchedules));
+    }
+
+    return { nextSchedule, previousSchedule, status, statusType };
+  })();
 
   const handleDetailsClick = (e: React.MouseEvent) => {
     e.stopPropagation();


### PR DESCRIPTION
⚡ Bolt: Optimized `LineCard` schedule calculation.

💡 What:
- Extracted the parsing of schedule strings (string -> minutes) and sorting into a `useMemo` hook.
- Moved the calculation of "Next Schedule" and "Status" (which depends on `currentMinutes`) to run on every render.

🎯 Why:
- Previous implementation memoized the *entire* calculation including `new Date()`. This meant the component would show stale time (e.g., "Next bus at 10:00" even if it's 10:15) until `linha.horarios` prop changed.
- Parsing and sorting schedule strings is O(N log N) (or O(N) if already sorted) and relatively expensive. By memoizing it, we avoid this work on re-renders.
- Status calculation is O(N) (linear scan) and very cheap, so running it on every render ensures correctness without performance penalty.

📊 Impact:
- Fixes a correctness bug where time was stale.
- Optimizes rendering by skipping schedule parsing/sorting on re-renders triggered by parent (e.g., search input changes).

🔬 Measurement:
- Verified visually via Playwright screenshot that the component renders correctly with expected data.
- Verified that `pnpm build` and `pnpm lint` pass.

---
*PR created automatically by Jules for task [5434107673864980021](https://jules.google.com/task/5434107673864980021) started by @igormartins4*