### PR TITLE
⚡ Bolt: [optimize LinhaDetalhesModal re-renders]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - LinhaDetalhesModal Re-renders
+**Learning:** Found a specific codebase bottleneck in `LinhaDetalhesModal.tsx` where expensive array operations (searching for stops via IDs and parsing/sorting schedule strings) were not memoized. As a result, simply switching between the "Itinerário" and "Todos os Horários" tabs was re-executing O(N*M) lookups and re-sorting arrays on every tab change render.
+**Action:** Always wrap derived data calculations that involve sorting or deep array lookups (like `buscarParadasPorIds`) in `useMemo`, particularly in Modals that have internal state variables (like active tabs) that trigger frequent re-renders.

--- a/app/src/components/LinhaDetalhesModal.tsx
+++ b/app/src/components/LinhaDetalhesModal.tsx
@@ -3,7 +3,7 @@
  * Design System - Interno Rotas UFMG
  */
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { tv } from "tailwind-variants";
 import { Clock, Map, MapPin, Bus } from "lucide-react";
 import { Modal } from "./Modal";
@@ -139,26 +139,37 @@ export function LinhaDetalhesModal({
   useSessionTiming(`Linha: ${linha.nome}`, "Engajamento Detalhes");
 
   // Buscar paradas do itinerário dinamicamente usando os IDs
-  const paradasDoItinerario = buscarParadasPorIds(
-    linha.itinerarioParadasIds,
-    todasParadas,
+  // ⚡ Bolt: Memoizing O(N*M) lookup to prevent recalculation when switching modal tabs
+  const paradasDoItinerario = useMemo(
+    () => buscarParadasPorIds(linha.itinerarioParadasIds, todasParadas),
+    [linha.itinerarioParadasIds, todasParadas],
   );
 
   // Calcular horários passados e futuros
   const now = new Date();
   const currentMinutes = now.getHours() * 60 + now.getMinutes();
 
-  const horariosOrganizados = linha.horarios
-    .filter((h) => h && h.includes(":"))
-    .map((horario) => ({
-      horario,
-      minutos: timeToMinutes(horario),
-      passou: timeToMinutes(horario) < currentMinutes,
-    }))
-    .sort((a, b) => a.minutos - b.minutos);
+  // ⚡ Bolt: Memoizing expensive time parsing and array sorting to prevent re-execution on every render
+  const horariosOrganizados = useMemo(() => {
+    return linha.horarios
+      .filter((h) => h && h.includes(":"))
+      .map((horario) => ({
+        horario,
+        minutos: timeToMinutes(horario),
+        passou: timeToMinutes(horario) < currentMinutes,
+      }))
+      .sort((a, b) => a.minutos - b.minutos);
+  }, [linha.horarios, currentMinutes]);
 
-  const proximos = horariosOrganizados.filter((h) => !h.passou);
-  const passados = horariosOrganizados.filter((h) => h.passou);
+  // ⚡ Bolt: Memoizing the derived filtered lists
+  const proximos = useMemo(
+    () => horariosOrganizados.filter((h) => !h.passou),
+    [horariosOrganizados],
+  );
+  const passados = useMemo(
+    () => horariosOrganizados.filter((h) => h.passou),
+    [horariosOrganizados],
+  );
 
   const handleTabChange = (tab: TabType) => {
     trackEvent({


### PR DESCRIPTION
💡 What: The `LinhaDetalhesModal` was unoptimized regarding array operations, specifically the `buscarParadasPorIds` function and the time parsing and sorting for `horarios`. These variables were being recalculated on every render, including tab switches. I wrapped these computations with React's `useMemo` hooks.
🎯 Why: Because of the heavy computations taking place in the render body, simply clicking between the "Itinerário" and "Todos os Horários" tabs was re-executing `buscarParadasPorIds` (an O(N*M) lookup against the whole stops data store) and sorting all schedule times on each render, leading to potential input latency on low-end devices.
📊 Impact: Reduces unnecessary re-execution of expensive array lookups and sorts when modifying local modal state (e.g., active tab), eliminating the O(N*M) bottleneck during standard navigation inside the modal.
🔬 Measurement: Verify the improvement by toggling tabs inside the details modal using a React Profiler or Performance Monitor; you will observe fewer script execution spikes and reduced overall render time.

---
*PR created automatically by Jules for task [7925184038016932242](https://jules.google.com/task/7925184038016932242) started by @igormartins4*