### PR TITLE
⚡ Bolt: [performance improvement] Optimize schedule processing memoization in modals

### DIFF
--- a/app/src/components/HorariosModal.tsx
+++ b/app/src/components/HorariosModal.tsx
@@ -105,16 +105,24 @@ export function HorariosModal({ isOpen, onClose, linha }: HorariosModalProps) {
   const shouldDisableSchedules =
     isInVacationPeriod && (!isVacationLine || isWeekend);
 
-  const horariosOrganizados = useMemo(() => {
+  // ⚡ Bolt: Memoize expensive schedule parsing/sorting separately from current time check.
+  // This prevents O(N log N) re-calculations on every render when time or other state changes.
+  const horariosParsed = useMemo(() => {
     return linha.horarios
       .filter((time) => time && time.includes(":"))
       .map((horario) => ({
         horario,
         minutos: timeToMinutes(horario),
-        passou: timeToMinutes(horario) < currentMinutes,
       }))
       .sort((a, b) => a.minutos - b.minutos);
-  }, [linha.horarios, currentMinutes]);
+  }, [linha.horarios]);
+
+  const horariosOrganizados = useMemo(() => {
+    return horariosParsed.map((h) => ({
+      ...h,
+      passou: h.minutos < currentMinutes,
+    }));
+  }, [horariosParsed, currentMinutes]);
 
   const proximos = horariosOrganizados.filter((h) => !h.passou);
   const passados = horariosOrganizados.filter((h) => h.passou);

--- a/app/src/components/LinhaDetalhesModal.tsx
+++ b/app/src/components/LinhaDetalhesModal.tsx
@@ -147,17 +147,24 @@ export function LinhaDetalhesModal({
   const now = new Date();
   const currentMinutes = now.getHours() * 60 + now.getMinutes();
 
-  // Memoizar parsing e ordenação custosa dos horários
-  const horariosOrganizados = useMemo(() => {
+  // ⚡ Bolt: Memoize expensive schedule parsing/sorting separately from current time check.
+  // This prevents O(N log N) re-calculations when the active tab or current minutes change.
+  const horariosParsed = useMemo(() => {
     return linha.horarios
       .filter((h) => h && h.includes(":"))
       .map((horario) => ({
         horario,
         minutos: timeToMinutes(horario),
-        passou: timeToMinutes(horario) < currentMinutes,
       }))
       .sort((a, b) => a.minutos - b.minutos);
-  }, [linha.horarios, currentMinutes]);
+  }, [linha.horarios]);
+
+  const horariosOrganizados = useMemo(() => {
+    return horariosParsed.map((h) => ({
+      ...h,
+      passou: h.minutos < currentMinutes,
+    }));
+  }, [horariosParsed, currentMinutes]);
 
   // Memoizar listas filtradas derivadas
   const proximos = useMemo(


### PR DESCRIPTION
💡 **What:** Extracted the schedule sorting and parsing logic into an independent `useMemo` hook that depends only on the raw schedule strings, decoupled from the time-dependent `passou` check.
🎯 **Why:** To prevent heavy string splits (`timeToMinutes`) and O(N log N) array sorts from running unnecessarily on every render when the time (`currentMinutes`) changes or when switching tabs in the details modal.
📊 **Impact:** Reduces component re-render cost and prevents UI lag when the system clock updates the schedule statuses. Time-dependent operations are now just an O(N) map.
🔬 **Measurement:** Verify performance by profiling the render cycle when navigating between tabs in `LinhaDetalhesModal` or observing render cycles in `HorariosModal` as `currentMinutes` shifts. The list output remains functionally identical.

---
*PR created automatically by Jules for task [10373590758966419906](https://jules.google.com/task/10373590758966419906) started by @igormartins4*