### PR TITLE
🎨 Palette: [UX improvement] Add keyboard accessibility to schedule cards

### DIFF
--- a/app/src/components/LineCard.tsx
+++ b/app/src/components/LineCard.tsx
@@ -198,9 +198,7 @@ function SuspendedNotice({ message }: SuspendedNoticeProps) {
       data-slot="notice"
       className="mb-4 rounded-lg border border-red-600/50 bg-red-900/20 p-3 text-center"
     >
-      <p className="text-xs font-semibold text-red-300 md:text-sm">
-        {message}
-      </p>
+      <p className="text-xs font-semibold text-red-300 md:text-sm">{message}</p>
     </div>
   );
 }

--- a/app/src/components/LinhaDetalhesModal.tsx
+++ b/app/src/components/LinhaDetalhesModal.tsx
@@ -188,6 +188,13 @@ export function LinhaDetalhesModal({
     });
   };
 
+  const handleHorarioKeyDown = (e: React.KeyboardEvent, horario: string) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleHorarioClick(horario);
+    }
+  };
+
   const handleParadaClick = (parada: Parada) => {
     trackEvent({
       category: "Engajamento Detalhes",
@@ -368,7 +375,11 @@ export function LinhaDetalhesModal({
                   <div
                     key={`proximo-${minutos}-${index}`}
                     onClick={() => handleHorarioClick(horario)}
+                    onKeyDown={(e) => handleHorarioKeyDown(e, horario)}
                     className={scheduleCardVariants({ status: "upcoming" })}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Próximo horário às ${horario}`}
                     style={{
                       borderColor: linha.corHex,
                       backgroundColor: `${linha.corHex}20`,
@@ -398,7 +409,11 @@ export function LinhaDetalhesModal({
                   <div
                     key={`passado-${minutos}-${index}`}
                     onClick={() => handleHorarioClick(horario)}
+                    onKeyDown={(e) => handleHorarioKeyDown(e, horario)}
                     className={scheduleCardVariants({ status: "passed" })}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Horário passado às ${horario}`}
                   >
                     <p className="text-lg font-semibold text-text-secondary">
                       {horario}


### PR DESCRIPTION
💡 What: Added keyboard accessibility attributes (`tabIndex={0}`, `role="button"`, `aria-label`) and an `onKeyDown` handler (for "Enter" and "Space" keys) to the interactive schedule cards in `LinhaDetalhesModal.tsx`.
🎯 Why: The schedule cards were clickable (`onClick` handler was present for analytics tracking) and had hover states, but they were inaccessible to keyboard-only users who rely on the Tab key to navigate interactive elements.
📸 Before/After: Visual appearance is largely unchanged (except for `focus-visible` outlines when tabbing), but the cards are now properly focusable and operable via keyboard.
♿ Accessibility: Improved keyboard navigation and screen reader support for the schedule cards, aligning with the ARIA button pattern.

---
*PR created automatically by Jules for task [14928087456171994475](https://jules.google.com/task/14928087456171994475) started by @igormartins4*