### PR TITLE
🎨 Palette: [UX improvement] Add full accessibility support to schedule cards in LinhaDetalhesModal

### DIFF
--- a/app/src/components/LineCard.tsx
+++ b/app/src/components/LineCard.tsx
@@ -198,9 +198,7 @@ function SuspendedNotice({ message }: SuspendedNoticeProps) {
       data-slot="notice"
       className="mb-4 rounded-lg border border-red-600/50 bg-red-900/20 p-3 text-center"
     >
-      <p className="text-xs font-semibold text-red-300 md:text-sm">
-        {message}
-      </p>
+      <p className="text-xs font-semibold text-red-300 md:text-sm">{message}</p>
     </div>
   );
 }

--- a/app/src/components/LinhaDetalhesModal.tsx
+++ b/app/src/components/LinhaDetalhesModal.tsx
@@ -368,6 +368,15 @@ export function LinhaDetalhesModal({
                   <div
                     key={`proximo-${minutos}-${index}`}
                     onClick={() => handleHorarioClick(horario)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        handleHorarioClick(horario);
+                      }
+                    }}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Próximo horário às ${horario}`}
                     className={scheduleCardVariants({ status: "upcoming" })}
                     style={{
                       borderColor: linha.corHex,
@@ -398,6 +407,15 @@ export function LinhaDetalhesModal({
                   <div
                     key={`passado-${minutos}-${index}`}
                     onClick={() => handleHorarioClick(horario)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        handleHorarioClick(horario);
+                      }
+                    }}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Horário passado às ${horario}`}
                     className={scheduleCardVariants({ status: "passed" })}
                   >
                     <p className="text-lg font-semibold text-text-secondary">


### PR DESCRIPTION
### 💡 What
Added full keyboard and screen-reader accessibility to the schedule cards (próximos e passados) within the "Todos os Horários" tab of the `LinhaDetalhesModal`.

### 🎯 Why
The schedule cards are interactive elements (they have an `onClick` handler to trigger an event, such as analytics tracking). However, because they were built using standard `<div>` elements without any semantic roles, keyboard users could not tab to them or activate them via Enter/Space, and screen readers did not announce them as buttons. This change ensures that all interactive elements are correctly exposed to assistive technologies and can be fully operated without a mouse. 

### 📸 Before/After
*   **Before:** Schedule times were rendered as `div` elements with an `onClick` handler.
*   **After:** Schedule times are rendered as `div` elements with `role="button"`, `tabIndex={0}`, an explicit `aria-label` (e.g., "Próximo horário às 08:35"), and an `onKeyDown` handler that responds to Enter and Space key presses.

### ♿ Accessibility
*   **Keyboard Navigation:** Users can now navigate through the list of schedules using the `Tab` key.
*   **Keyboard Interaction:** The schedules can be "clicked" by pressing `Enter` or `Space` when focused.
*   **Screen Reader Context:** Screen readers will now announce these elements as buttons and read the contextual `aria-label`.

---
*PR created automatically by Jules for task [3443856977066759424](https://jules.google.com/task/3443856977066759424) started by @igormartins4*