### PR TITLE
🎨 Palette: Add tooltip to map locate button

### DIFF
--- a/app/src/components/ControlesUsuarioMapa.tsx
+++ b/app/src/components/ControlesUsuarioMapa.tsx
@@ -169,6 +169,11 @@ export function ControlesUsuarioMapa({
               ? "Centralizar mapa na minha localização"
               : "Ativar localização"
           }
+          title={
+            permissaoConcedida
+              ? "Centralizar mapa na minha localização"
+              : "Ativar localização"
+          }
         >
           <LocateFixed className="h-6 w-6 text-white" />
         </button>


### PR DESCRIPTION
💡 **What**: Added a `title` attribute to the "Locate User" icon-only button in `ControlesUsuarioMapa.tsx` that mirrors its `aria-label`.
🎯 **Why**: Sighted users relying on a mouse would not know what the icon button does until they clicked it. Adding the `title` attribute leverages the browser's native tooltip behavior, providing immediate, helpful context on hover. This fulfills Palette's goal of fixing missing tooltips for icon-only buttons.
📸 **Before/After**: Before, hovering over the crosshairs icon showed nothing. Now, it shows a native tooltip like "Centralizar mapa na minha localização".
♿ **Accessibility**: The button already had an `aria-label` for screen readers; this change brings parity to visual mouse users who need context for the icon.

---
*PR created automatically by Jules for task [10446310615689327078](https://jules.google.com/task/10446310615689327078) started by @igormartins4*