### PR TITLE
🛡️ Sentinel: [security improvement] Add referrer policy

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -10,6 +10,7 @@
     />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="theme-color" content="#2c0eeb" />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
 
     <title>Interno Rotas 🚌 | Horários e Rotas dos Ônibus da UFMG</title>
 

--- a/app/src/components/ControlesUsuarioMapa.tsx
+++ b/app/src/components/ControlesUsuarioMapa.tsx
@@ -12,7 +12,7 @@
 import { useMap } from "react-leaflet";
 import { Marker } from "react-leaflet";
 import L from "leaflet";
-import { CornerUpLeft , LocateFixed } from "lucide-react";
+import { CornerUpLeft, LocateFixed } from "lucide-react";
 import { cn } from "../lib/utils";
 import { COORDENADAS_UFMG } from "../hooks/useLocalizacaoUsuario";
 

--- a/app/src/hooks/useLocalizacaoUsuario.ts
+++ b/app/src/hooks/useLocalizacaoUsuario.ts
@@ -216,7 +216,11 @@ export function useLocalizacaoUsuario(): UseLocalizacaoUsuarioReturn {
       typeof window !== "undefined" &&
       window.DeviceOrientationEvent !== undefined;
     const requestPermission = isOrientationSupported
-      ? (window.DeviceOrientationEvent as unknown as { requestPermission?: () => Promise<"granted" | "denied"> }).requestPermission
+      ? (
+          window.DeviceOrientationEvent as unknown as {
+            requestPermission?: () => Promise<"granted" | "denied">;
+          }
+        ).requestPermission
       : undefined;
 
     if (typeof requestPermission === "function") {
@@ -244,7 +248,11 @@ export function useLocalizacaoUsuario(): UseLocalizacaoUsuarioReturn {
       ? "deviceorientationabsolute"
       : "deviceorientation";
 
-    window.addEventListener(eventName, handleOrientation as EventListener, true);
+    window.addEventListener(
+      eventName,
+      handleOrientation as EventListener,
+      true,
+    );
     return () =>
       window.removeEventListener(
         eventName,
@@ -352,10 +360,7 @@ export function useLocalizacaoUsuario(): UseLocalizacaoUsuarioReturn {
     () => setMostrarModalPermissao(false),
     [],
   );
-  const fecharModalLonge = useCallback(
-    () => setMostrarModalLonge(false),
-    [],
-  );
+  const fecharModalLonge = useCallback(() => setMostrarModalLonge(false), []);
 
   return {
     localizacao,


### PR DESCRIPTION
🚨 Severity: LOW/MEDIUM
💡 Vulnerability: Missing Referrer Policy
🎯 Impact: Without a strict Referrer Policy, sensitive URL paths or query parameters could potentially leak to external domains when a user clicks on an external link.
🔧 Fix: Added `<meta name="referrer" content="strict-origin-when-cross-origin" />` to `index.html`. This ensures that cross-origin requests only send the origin as the referrer, rather than the full URL, enhancing privacy and security without breaking functionality that requires origin information.
✅ Verification: Run `pnpm dev`, inspect the `index.html` headers in the network tab or the elements tab to verify the meta tag is present.

---
*PR created automatically by Jules for task [17589398576922292689](https://jules.google.com/task/17589398576922292689) started by @igormartins4*