### PR TITLE
🎨 Palette: Add tooltip to locate user button

### DIFF
--- a/app/src/components/ControlesUsuarioMapa.tsx
+++ b/app/src/components/ControlesUsuarioMapa.tsx
@@ -12,7 +12,7 @@
 import { useMap } from "react-leaflet";
 import { Marker } from "react-leaflet";
 import L from "leaflet";
-import { CornerUpLeft , LocateFixed } from "lucide-react";
+import { CornerUpLeft, LocateFixed } from "lucide-react";
 import { cn } from "../lib/utils";
 import { COORDENADAS_UFMG } from "../hooks/useLocalizacaoUsuario";
 
@@ -165,6 +165,11 @@ export function ControlesUsuarioMapa({
             "focus:outline-none focus:ring-2 focus:ring-brand-primary focus:ring-offset-2",
           )}
           aria-label={
+            permissaoConcedida
+              ? "Centralizar mapa na minha localização"
+              : "Ativar localização"
+          }
+          title={
             permissaoConcedida
               ? "Centralizar mapa na minha localização"
               : "Ativar localização"

--- a/app/src/hooks/useLocalizacaoUsuario.ts
+++ b/app/src/hooks/useLocalizacaoUsuario.ts
@@ -216,7 +216,11 @@ export function useLocalizacaoUsuario(): UseLocalizacaoUsuarioReturn {
       typeof window !== "undefined" &&
       window.DeviceOrientationEvent !== undefined;
     const requestPermission = isOrientationSupported
-      ? (window.DeviceOrientationEvent as unknown as { requestPermission?: () => Promise<"granted" | "denied"> }).requestPermission
+      ? (
+          window.DeviceOrientationEvent as unknown as {
+            requestPermission?: () => Promise<"granted" | "denied">;
+          }
+        ).requestPermission
       : undefined;
 
     if (typeof requestPermission === "function") {
@@ -244,7 +248,11 @@ export function useLocalizacaoUsuario(): UseLocalizacaoUsuarioReturn {
       ? "deviceorientationabsolute"
       : "deviceorientation";
 
-    window.addEventListener(eventName, handleOrientation as EventListener, true);
+    window.addEventListener(
+      eventName,
+      handleOrientation as EventListener,
+      true,
+    );
     return () =>
       window.removeEventListener(
         eventName,
@@ -352,10 +360,7 @@ export function useLocalizacaoUsuario(): UseLocalizacaoUsuarioReturn {
     () => setMostrarModalPermissao(false),
     [],
   );
-  const fecharModalLonge = useCallback(
-    () => setMostrarModalLonge(false),
-    [],
-  );
+  const fecharModalLonge = useCallback(() => setMostrarModalLonge(false), []);
 
   return {
     localizacao,


### PR DESCRIPTION
💡 **What:** Added a native `title` attribute to the icon-only "Locate User" (`<LocateFixed />`) floating action button in `ControlesUsuarioMapa.tsx`. The title mirrors the existing `aria-label` text.

🎯 **Why:** To improve micro-UX for sighted mouse users. Icon-only buttons can be ambiguous, and adding a native browser tooltip on hover immediately clarifies the button's purpose without requiring users to guess or rely solely on screen readers.

📸 **Before/After:** Before, hovering over the crosshair icon did nothing. After, hovering displays a tooltip reading "Centralizar mapa na minha localização" (or "Ativar localização" depending on state).

♿ **Accessibility:** While the button was already accessible to screen readers via `aria-label`, this improves cognitive accessibility and general usability for sighted users.

---
*PR created automatically by Jules for task [18255731395856135578](https://jules.google.com/task/18255731395856135578) started by @igormartins4*