### PR TITLE
🎨 Palette: Add native tooltips to icon-only buttons

### DIFF
--- a/app/.Jules/palette.md
+++ b/app/.Jules/palette.md
@@ -7,3 +7,8 @@
 
 **Learning:** Found that custom `<article>` based clickable cards (`LineCard`) did not support keyboard interactions natively because adding `role="button"` was invalid HTML nesting due to inner buttons ("Ver Detalhes").
 **Action:** Implemented `tabIndex={0}`, `aria-label`, and `onKeyDown` handlers on the container instead of `role="button"` to allow Enter/Space interactions while maintaining valid HTML structure.
+
+## 2024-03-01 - Native Tooltips on Icon-Only Buttons
+
+**Learning:** While `aria-label` provides necessary context for screen readers on icon-only buttons (like modal close buttons, search clear buttons, and map controls), sighted mouse users lack this context because `aria-label` is not visually rendered. Adding a matching `title` attribute provides a native browser tooltip, bridging this usability gap.
+**Action:** Ensure that any icon-only button components (`<DialogClose>`, `<SearchInput>` clear, map FABs) always pair `aria-label` with a matching `title` attribute.

--- a/app/src/components/ControlesUsuarioMapa.tsx
+++ b/app/src/components/ControlesUsuarioMapa.tsx
@@ -12,7 +12,7 @@
 import { useMap } from "react-leaflet";
 import { Marker } from "react-leaflet";
 import L from "leaflet";
-import { CornerUpLeft , LocateFixed } from "lucide-react";
+import { CornerUpLeft, LocateFixed } from "lucide-react";
 import { cn } from "../lib/utils";
 import { COORDENADAS_UFMG } from "../hooks/useLocalizacaoUsuario";
 
@@ -165,6 +165,11 @@ export function ControlesUsuarioMapa({
             "focus:outline-none focus:ring-2 focus:ring-brand-primary focus:ring-offset-2",
           )}
           aria-label={
+            permissaoConcedida
+              ? "Centralizar mapa na minha localização"
+              : "Ativar localização"
+          }
+          title={
             permissaoConcedida
               ? "Centralizar mapa na minha localização"
               : "Ativar localização"

--- a/app/src/components/HeaderMobile.tsx
+++ b/app/src/components/HeaderMobile.tsx
@@ -80,6 +80,7 @@ export function HeaderMobile({
         onClick={toggleMenu}
         className={menuButtonVariants()}
         aria-label={isMenuOpen ? "Fechar menu" : "Abrir menu"}
+        title={isMenuOpen ? "Fechar menu" : "Abrir menu"}
         aria-expanded={isMenuOpen}
       >
         {isMenuOpen ? <X className="size-7" /> : <Menu className="size-7" />}

--- a/app/src/components/ui/Dialog.tsx
+++ b/app/src/components/ui/Dialog.tsx
@@ -342,6 +342,7 @@ function DialogClose({
       onClick={handleClick}
       className={cn(dialogCloseVariants(), className)}
       aria-label={ariaLabel}
+      title={ariaLabel}
       {...props}
     >
       {children ?? <X className="size-6" />}

--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -260,6 +260,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
             onClick={handleClear}
             className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full p-0.5 text-text-secondary transition-colors cursor-pointer hover:bg-card-hover hover:text-text-primary"
             aria-label="Limpar busca"
+            title="Limpar busca"
           >
             <X size={16} />
           </button>

--- a/app/src/hooks/useLocalizacaoUsuario.ts
+++ b/app/src/hooks/useLocalizacaoUsuario.ts
@@ -216,7 +216,11 @@ export function useLocalizacaoUsuario(): UseLocalizacaoUsuarioReturn {
       typeof window !== "undefined" &&
       window.DeviceOrientationEvent !== undefined;
     const requestPermission = isOrientationSupported
-      ? (window.DeviceOrientationEvent as unknown as { requestPermission?: () => Promise<"granted" | "denied"> }).requestPermission
+      ? (
+          window.DeviceOrientationEvent as unknown as {
+            requestPermission?: () => Promise<"granted" | "denied">;
+          }
+        ).requestPermission
       : undefined;
 
     if (typeof requestPermission === "function") {
@@ -244,7 +248,11 @@ export function useLocalizacaoUsuario(): UseLocalizacaoUsuarioReturn {
       ? "deviceorientationabsolute"
       : "deviceorientation";
 
-    window.addEventListener(eventName, handleOrientation as EventListener, true);
+    window.addEventListener(
+      eventName,
+      handleOrientation as EventListener,
+      true,
+    );
     return () =>
       window.removeEventListener(
         eventName,
@@ -352,10 +360,7 @@ export function useLocalizacaoUsuario(): UseLocalizacaoUsuarioReturn {
     () => setMostrarModalPermissao(false),
     [],
   );
-  const fecharModalLonge = useCallback(
-    () => setMostrarModalLonge(false),
-    [],
-  );
+  const fecharModalLonge = useCallback(() => setMostrarModalLonge(false), []);
 
   return {
     localizacao,


### PR DESCRIPTION
💡 **What:**
Added native `title` attributes to multiple icon-only buttons (such as the map location control, header mobile hamburger menu, dialog close button, and search input clear button). 

🎯 **Why:**
While these buttons already had `aria-label`s for screen-reader users, sighted mouse users had no visual way of knowing what the icons did before clicking them. Adding a `title` attribute matching the `aria-label` exposes the same critical context natively as a browser tooltip on hover.

📸 **Before/After:**
- **Before:** Hovering over the location dot button or the 'X' button in a dialog did nothing visually. Sighted users had to guess their function based solely on the icon.
- **After:** Hovering over these elements now displays a helpful native browser tooltip (e.g., "Centralizar no meu local" or "Fechar dialog").

♿ **Accessibility:**
Provides critical context for users who rely on visual feedback and mouse interactions but may not immediately recognize abstract iconography, while keeping the DOM clean and aligned with existing screen-reader labels.

---
*PR created automatically by Jules for task [8260671777165839692](https://jules.google.com/task/8260671777165839692) started by @igormartins4*