### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to development servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -8,10 +8,20 @@ export default defineConfig({
   plugins: [react(), tailwindcss(), ghPages()],
   base: '/ufmg/',
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse node_modules do workspace
       // raiz (pnpm usa symlinks que resolvem para fora do diretório app/).
       allow: ['..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add security headers to development servers

Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` HTTP headers to Vite's `server` and `preview` configs.

**Severity:** MEDIUM
**Vulnerability:** Missing HTTP security headers during local development and preview environments (specifically X-Content-Type-Options and X-Frame-Options).
**Impact:** Missing them in local development risks vulnerabilities slipping through to production untested and exposes local environments to vectors like MIME-type sniffing and clickjacking.
**Fix:** Configured `server.headers` and `preview.headers` in `vite.config.ts`.
**Verification:** Checked `pnpm dev` config, ran `pnpm lint` and `pnpm test` successfully.

---
*PR created automatically by Jules for task [7640085174048726627](https://jules.google.com/task/7640085174048726627) started by @igormartins4*