### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-03-24 - Missing HTTP Security Headers in Vite
+**Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options) in local development and preview environments.
+**Learning:** The browser ignores `X-Content-Type-Options: nosniff` if it is delivered via an HTML `<meta>` tag; it must be set as an actual HTTP response header to be effective. The `frame-ancestors` CSP directive is not supported when using `<meta>` tags and must be excluded from policies defined in HTML. Setting these headers in `vite.config.ts` ensures defense-in-depth during development and preview.
+**Prevention:** Configure `server.headers` and `preview.headers` in `vite.config.ts` to include standard HTTP security headers like `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`.

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -8,10 +8,20 @@ export default defineConfig({
   plugins: [react(), tailwindcss(), ghPages()],
   base: '/ufmg/',
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse node_modules do workspace
       // raiz (pnpm usa symlinks que resolvem para fora do diretório app/).
       allow: ['..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing security headers (`X-Content-Type-Options`, `X-Frame-Options`) in local development and preview environments. Setting these via HTML `<meta>` tags has limitations (e.g., `nosniff` is ignored, `frame-ancestors` is invalid).
🎯 **Impact:** Exposes the development and preview environments to potential MIME-type sniffing and Clickjacking attacks. Although these are non-production environments, applying defense-in-depth at all stages is a best practice.
🔧 **Fix:** Configured `server.headers` and `preview.headers` in `vite.config.ts` to include standard HTTP security headers (`X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`), enforcing these protections at the HTTP response level.
✅ **Verification:** Ran `pnpm format`, `pnpm lint`, and Playwright tests locally to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [8083580945299870932](https://jules.google.com/task/8083580945299870932) started by @igormartins4*