### PR TITLE
⚡ Bolt: Prevent redundant schedule parsing in LineCard

### DIFF
--- a/app/src/components/LineCard.tsx
+++ b/app/src/components/LineCard.tsx
@@ -197,10 +197,12 @@ function LineCardComponent({
   const shouldDisableSchedules = !isLineAvailableToday(linha.categoriaDia);
   const getSuspendedMessage = () => getLinhaNotRunningMessage(linha.categoriaDia);
 
+  const todayKey = now.toDateString();
   const schedulesInMinutes = useMemo(() => {
-    const horariosDoDia = obterHorariosLinhaNoDia(linha, now);
+    const referenceDate = new Date(todayKey);
+    const horariosDoDia = obterHorariosLinhaNoDia(linha, referenceDate);
     return parseSchedules(horariosDoDia);
-  }, [linha, now]);
+  }, [linha, todayKey]);
 
   // Passa schedulesInMinutes para obterStatusLinha para evitar recálculo O(N log N)
   const statusLinha = obterStatusLinha(linha, now, schedulesInMinutes);


### PR DESCRIPTION
💡 **What:** Changed the dependency of `schedulesInMinutes` memoization in `LineCard.tsx` from `now` (which updates every 30 seconds) to `todayKey` (which only changes when the day changes).

🎯 **Why:** `schedulesInMinutes` calculates the baseline schedule for the day, which requires filtering, parsing, and sorting an array (an O(N log N) operation). Because it previously depended on `now`, it was recalculating this static daily schedule every 30 seconds, needlessly consuming CPU cycles in a hot path component.

📊 **Impact:** Reduces redundant O(N log N) computations to once per day per component, saving significant processing time over the application lifecycle, especially since `LineCard` is rendered many times in lists.

🔬 **Measurement:** Code Review confirms that `schedulesInMinutes` is now only computed when `linha` or `todayKey` change, while exact correctness of `obterStatusLinha` is preserved since it still checks the current `now`. Run `pnpm lint` and `pnpm test` successfully.

---
*PR created automatically by Jules for task [9334756557752817288](https://jules.google.com/task/9334756557752817288) started by @igormartins4*