### PR TITLE
🛡️ Sentinel: [LOW] Allow Google Fonts in Content-Security-Policy

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,7 +6,7 @@
     <!-- Content Security Policy for defense in depth -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://www.googletagmanager.com ws: wss:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self';"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://www.googletagmanager.com ws: wss:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self';"
     />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="theme-color" content="#2c0eeb" />


### PR DESCRIPTION
🚨 Severity: LOW / Enhancment
💡 Vulnerability: The Content-Security-Policy was overly restrictive, blocking legitimate Google Fonts which caused styling and font issues, potentially degrading the user experience and breaking visual design.
🎯 Impact: Improved application functionality and layout by allowing intended fonts to load without violating the CSP.
🔧 Fix: Added Google Fonts domains (`fonts.googleapis.com` for styles and `fonts.gstatic.com` for fonts) to the CSP meta tag.
✅ Verification: Ran `pnpm test` and `pnpm lint` in `app/`.

---
*PR created automatically by Jules for task [5437641857662462600](https://jules.google.com/task/5437641857662462600) started by @igormartins4*