### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to dev/preview servers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-09 - Missing HTTP Security Headers in Local Servers
+**Vulnerability:** The Vite development (`server`) and preview (`preview`) environments were missing crucial security headers like `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`.
+**Learning:** Even though the app is destined for static hosting (GitHub Pages) where custom headers might not be applicable directly, local dev and preview servers should still mirror production security best practices. The `X-Content-Type-Options: nosniff` header is especially tricky; the browser ignores it if delivered via an HTML `<meta>` tag, meaning it MUST be set as an actual HTTP response header.
+**Prevention:** Always configure explicit HTTP security headers in modern frontend tooling (like Vite) under `server.headers` and `preview.headers` to ensure a "secure by default" posture across all deployment and development stages.

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -8,10 +8,20 @@ export default defineConfig({
   plugins: [react(), tailwindcss(), ghPages()],
   base: '/ufmg/',
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse node_modules do workspace
       // raiz (pnpm usa symlinks que resolvem para fora do diretório app/).
       allow: ['..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The Vite development and preview servers were missing fundamental HTTP security headers. While the app uses `<meta http-equiv="Content-Security-Policy">`, certain headers like `X-Content-Type-Options` and `X-Frame-Options` must be delivered as actual HTTP headers to be respected by modern browsers.
🎯 **Impact:** Without `nosniff`, browsers could perform MIME-sniffing and incorrectly execute non-script resources as scripts. Without `X-Frame-Options: DENY`, the local servers could be embedded in malicious iframes, potentially increasing the risk of clickjacking or data exposure during development and testing phases.
🔧 **Fix:** Configured `server.headers` and `preview.headers` in `vite.config.ts` to strictly apply `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`.
✅ **Verification:** Ran `pnpm lint` and `pnpm test` successfully. To verify the headers are applied, run `pnpm dev` or `pnpm preview` and inspect the Network tab in browser devtools, confirming the response headers are present on initial document requests.

---
*PR created automatically by Jules for task [3938415652368148527](https://jules.google.com/task/3938415652368148527) started by @igormartins4*