### PR TITLE
⚡ Bolt: Optimize LineCard memoization

### DIFF
--- a/app/src/components/LineCard.tsx
+++ b/app/src/components/LineCard.tsx
@@ -197,10 +197,13 @@ function LineCardComponent({
   const shouldDisableSchedules = !isLineAvailableToday(linha.categoriaDia);
   const getSuspendedMessage = () => getLinhaNotRunningMessage(linha.categoriaDia);
 
+  const todayKey = now.toDateString();
+
   const schedulesInMinutes = useMemo(() => {
-    const horariosDoDia = obterHorariosLinhaNoDia(linha, now);
+    const referenceDate = new Date(todayKey);
+    const horariosDoDia = obterHorariosLinhaNoDia(linha, referenceDate);
     return parseSchedules(horariosDoDia);
-  }, [linha, now]);
+  }, [linha, todayKey]);
 
   // Passa schedulesInMinutes para obterStatusLinha para evitar recálculo O(N log N)
   const statusLinha = obterStatusLinha(linha, now, schedulesInMinutes);


### PR DESCRIPTION
## 💡 What:
Optimized the `LineCard` component's `useMemo` hook that calculates `schedulesInMinutes`. Previously, it depended on `now` (the result of `useCurrentTime()`), which updates every 30 seconds. This caused `parseSchedules`—an O(N log N) sorting operation—to be recalculated unnecessarily every 30 seconds. By depending on `now.toDateString()` (`todayKey`) instead, the computation only runs once per day per line, since daily schedules do not change within the same day.

## 🎯 Why:
To prevent redundant `O(N log N)` schedule parsing operations that run every 30 seconds globally across all active `LineCard` components, reducing CPU overhead and unnecessary re-renders.

## 📊 Impact:
Reduces redundant executions of `parseSchedules` from once every 30 seconds to once per day per active LineCard component. This significantly lowers main-thread blocking time in lists containing multiple line cards.

## 🔬 Measurement:
Start the development server and search for a few lines. Observe React DevTools Profiler or the Console (if adding a temporary `console.log` inside the `useMemo`). The recalculation will only trigger when the day changes instead of every 30 seconds.

---
*PR created automatically by Jules for task [10441196551321134005](https://jules.google.com/task/10441196551321134005) started by @igormartins4*