### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to Vite dev server

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -8,10 +8,20 @@ export default defineConfig({
   plugins: [react(), tailwindcss(), ghPages()],
   base: '/ufmg/',
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse node_modules do workspace
       // raiz (pnpm usa symlinks que resolvem para fora do diretório app/).
       allow: ['..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP Security Headers (X-Content-Type-Options and X-Frame-Options) in local development and preview environments. Browsers ignore X-Content-Type-Options when delivered via an HTML <meta> tag.
🎯 Impact: Without nosniff, browsers can be tricked into interpreting files as a different MIME type. Without DENY on X-Frame-Options, clickjacking attacks are possible (though limited locally).
🔧 Fix: Added explicit HTTP headers to `app/vite.config.ts` under both `server.headers` and `preview.headers` to provide defense-in-depth for developers.
✅ Verification: Ran `pnpm lint` and Playwright tests to ensure configuration is valid and no regressions occurred.

---
*PR created automatically by Jules for task [2309584305534211294](https://jules.google.com/task/2309584305534211294) started by @igormartins4*