### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to Vite dev/preview server

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -20,6 +20,16 @@ export default defineConfig({
       // raiz (pnpm usa symlinks que resolvem para fora do diretório app/).
       allow: ['..'],
     },
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
   },
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(packageJson.version),


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The HTTP response headers `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` were missing from the application's local development server and preview server configurations. The `X-Content-Type-Options` header is ignored when specified within an HTML `<meta>` tag, rendering the tag ineffective.
🎯 Impact: Without `X-Content-Type-Options`, browsers may perform MIME sniffing, leading to potential Cross-Site Scripting (XSS) if user-uploaded content is incorrectly interpreted as HTML or JavaScript. Without `X-Frame-Options`, the application could be vulnerable to Clickjacking.
🔧 Fix: Added the `headers` block to `server` and `preview` configurations in `app/vite.config.ts` to ensure these headers are sent via actual HTTP responses during local development and preview serving. Also documented this learning in `.jules/sentinel.md`.
✅ Verification: Review `app/vite.config.ts` changes. Tests ran without introducing new regressions.

---
*PR created automatically by Jules for task [855488040744266780](https://jules.google.com/task/855488040744266780) started by @igormartins4*