### PR TITLE
⚡ Bolt: Optimize schedules memoization in LineCard

### DIFF
--- a/app/src/components/LineCard.tsx
+++ b/app/src/components/LineCard.tsx
@@ -198,10 +198,13 @@ function LineCardComponent({
   const shouldDisableSchedules = !isLineAvailableToday(linha.categoriaDia);
   const getSuspendedMessage = () => getLinhaNotRunningMessage(linha.categoriaDia);
 
+  const todayKey = now.toDateString();
+
   const schedulesInMinutes = useMemo(() => {
-    const horariosDoDia = obterHorariosLinhaNoDia(linha, now);
+    const referenceDate = new Date(todayKey);
+    const horariosDoDia = obterHorariosLinhaNoDia(linha, referenceDate);
     return parseSchedules(horariosDoDia);
-  }, [linha, now]);
+  }, [linha, todayKey]);
 
   // Passa schedulesInMinutes para obterStatusLinha para evitar recálculo O(N log N)
   const statusLinha = obterStatusLinha(linha, now, schedulesInMinutes);


### PR DESCRIPTION
💡 **What:** Extracted `todayKey = now.toDateString()` from the reactive `now` value, and updated the `schedulesInMinutes` memoization array to depend on `todayKey` instead of `now`. Reconstructed `referenceDate = new Date(todayKey)` inside the memo block to pass to `obterHorariosLinhaNoDia`.

🎯 **Why:** Previously, the `schedulesInMinutes` list was recalculated (triggering an O(N log N) parse and sort operation) every time `now` updated (which happens every 30 seconds via `useCurrentTime`). Since bus schedules don't change during the day, recalculating this every 30 seconds for every visible card is a waste of CPU. By memoizing based on the local day string, the calculation runs only once per day per component.

📊 **Impact:** Reduces O(N log N) parsing and sorting of schedules by 100% after initial load, eliminating unnecessary CPU spikes every 30 seconds.

🔬 **Measurement:** Verify by placing a `console.log` inside the `useMemo` block in `LineCard.tsx`. Without the patch, it prints every 30 seconds. With the patch, it only prints on initial mount or when the day changes.

---
*PR created automatically by Jules for task [9411583514098388674](https://jules.google.com/task/9411583514098388674) started by @igormartins4*