### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -20,6 +20,16 @@ export default defineConfig({
       // raiz (pnpm usa symlinks que resolvem para fora do diretório app/).
       allow: ['..'],
     },
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
   },
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(packageJson.version),


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The Vite development and preview servers were missing HTTP security headers like `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`. While present in HTML `<meta>` tags, browsers ignore certain security tags (like nosniff) when delivered this way; they must be actual HTTP response headers.
🎯 **Impact**: Relying on HTML meta tags for security configurations that require HTTP response headers leaves the development and preview environments susceptible to MIME-type sniffing and potential clickjacking.
🔧 **Fix**: Added explicit HTTP headers to `app/vite.config.ts` under the `server.headers` and `preview.headers` blocks to ensure defense-in-depth across environments. Also recorded this critical learning to `.jules/sentinel.md`.
✅ **Verification**: Run `cd app && pnpm test` to verify the build is unbroken, or start the dev server `pnpm dev` and inspect the Network tab headers.

---
*PR created automatically by Jules for task [1562568299404185543](https://jules.google.com/task/1562568299404185543) started by @igormartins4*