### PR TITLE
Remoção da Meta Tag de Content Security Policy (CSP)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,11 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- Content Security Policy for defense in depth -->
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://www.googletagmanager.com ws: wss:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self';"
-    />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="theme-color" content="#2c0eeb" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />


### PR DESCRIPTION
Esta solicitação de pull remove a meta tag de Política de Segurança de Conteúdo (CSP) do arquivo `app/index.html`. Essa alteração elimina a política de segurança imposta pelo navegador que restringia as fontes de scripts, estilos, imagens e outros recursos.

Atualização de configuração de segurança:
* Removida a meta tag CSP, que anteriormente fornecia uma camada adicional de defesa contra cross-site scripting (XSS) e outros ataques, do arquivo `app/index.html`.