### PR TITLE
🛡️ Sentinel: Add security headers to Vite dev server

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -69,10 +69,20 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse node_modules do workspace
       // raiz (pnpm usa symlinks que resolvem para fora do diretório app/).
       allow: ['..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers (X-Content-Type-Options, X-Frame-Options) in local development and preview environments.
🎯 Impact: Without `X-Content-Type-Options: nosniff`, browsers may try to guess the MIME type, potentially executing malicious scripts hidden in non-executable files. Without `X-Frame-Options: DENY`, the application could be embedded in a malicious iframe, leading to clickjacking attacks.
🔧 Fix: Configured Vite's `server.headers` and `preview.headers` to explicitly inject these security headers.
✅ Verification: Tested via local inspection; run Vite dev/preview to verify headers in DevTools. Linters and tests run.

---
*PR created automatically by Jules for task [11878947089508697783](https://jules.google.com/task/11878947089508697783) started by @igormartins4*