### PR TITLE
🛡️ Sentinel: [MEDIUM] Add basic HTTP security headers for dev/preview

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -74,6 +74,20 @@ export default defineConfig({
       // raiz (pnpm usa symlinks que resolvem para fora do diretório app/).
       allow: ['..'],
     },
+    headers: {
+      // 🛡️ Sentinel: Add security headers
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+    },
+  },
+  preview: {
+    headers: {
+      // 🛡️ Sentinel: Add security headers
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+    },
   },
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(packageJson.version),


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing basic HTTP security headers (like X-Content-Type-Options, X-Frame-Options) in local development and preview environments.
🎯 Impact: While not a direct production vulnerability (as production servers typically set these), omitting them locally breaks parity with secure production environments, potentially masking clickjacking or MIME-sniffing vulnerabilities during development testing.
🔧 Fix: Configured `server.headers` and `preview.headers` in `vite.config.ts` to include standard security headers (`X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `X-XSS-Protection: 1; mode=block`).
✅ Verification: Start the local dev server (`pnpm dev`) or preview server (`pnpm preview`) and inspect network tab responses to verify the headers are returned. Tests and linters pass successfully.

---
*PR created automatically by Jules for task [10808577511040004858](https://jules.google.com/task/10808577511040004858) started by @igormartins4*