### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to dev/preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers (`X-Content-Type-Options`, `X-Frame-Options`) on local dev/preview environments.
🎯 Impact: While primarily for local testing, missing these headers creates a discrepancy with production security controls and allows potential MIME-sniffing or clickjacking against the development environment if an attacker can trick a developer into visiting a malicious local page.
🔧 Fix: Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to both the `server.headers` and `preview.headers` configurations in `app/vite.config.ts`.
✅ Verification: Ran `pnpm test` and `pnpm build` successfully, confirming no build or functional regressions.

---
*PR created automatically by Jules for task [11485511036585703226](https://jules.google.com/task/11485511036585703226) started by @igormartins4*