### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing security headers in Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The Vite development and preview servers were missing fundamental security headers (`X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`), which could potentially expose the application to MIME-sniffing and clickjacking attacks when tested in local or preview environments.
🎯 **Impact:** While production servers usually apply these headers, missing them locally reduces defense-in-depth and fails to emulate production behavior safely.
🔧 **Fix:** Added `server.headers` and `preview.headers` configurations in `vite.config.ts`.
✅ **Verification:** Verified that tests pass and the code compiles without regressions.

---
*PR created automatically by Jules for task [1451877568859412976](https://jules.google.com/task/1451877568859412976) started by @igormartins4*