### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite dev and preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing HTTP Security Headers (Defense in Depth)
🎯 **Impact:** Without strict security headers configured locally, developers might unknowingly introduce vulnerabilities or behaviors that are allowed in dev but blocked in production. For instance, relying on implicit MIME-type sniffing, or building UI elements meant to be embedded via iframe which would be blocked by a production `X-Frame-Options` header.
🔧 **Fix:** Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to `server.headers` and `preview.headers` blocks in `vite.config.ts`.
✅ **Verification:** Verified via Vite configuration check and `pnpm lint`, `pnpm test`, and `pnpm build`. Dev and preview servers will now serve these headers directly on all requests.

---
*PR created automatically by Jules for task [10131997440346342171](https://jules.google.com/task/10131997440346342171) started by @igormartins4*