### PR TITLE
🎨 Palette: Add explicit type="button" to ThemeToggle

### DIFF
--- a/app/src/components/ThemeToggle.tsx
+++ b/app/src/components/ThemeToggle.tsx
@@ -77,6 +77,7 @@ export function ThemeToggle({
 
   return (
     <button
+      type="button"
       data-slot="toggle"
       data-state={isDark ? 'dark' : 'light'}
       onClick={handleToggle}


### PR DESCRIPTION
💡 **What:** Added `type="button"` to the `<button>` element inside `app/src/components/ThemeToggle.tsx`.

🎯 **Why:** To prevent the button from inadvertently acting as a submit button (the default browser behavior for `<button>`) if it's ever placed inside or near a `<form>`, thereby avoiding accidental form submissions or page reloads.

♿ **Accessibility/UX:** Improves the predictability and robustness of the `ThemeToggle` component, ensuring it solely functions as a UI toggle regardless of its surrounding context.

---
*PR created automatically by Jules for task [10080686964355306207](https://jules.google.com/task/10080686964355306207) started by @igormartins4*