### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to development server

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers in local development and preview environments.
🎯 Impact: Could allow MIME-sniffing and clickjacking attacks in local environments, deviating from production parity and safe development practices.
🔧 Fix: Configured Vite `server.headers` and `preview.headers` to explicitly add `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`.
✅ Verification: `pnpm lint` and `pnpm test` pass. Build succeeds.

---
*PR created automatically by Jules for task [4008094902187002650](https://jules.google.com/task/4008094902187002650) started by @igormartins4*