### PR TITLE
🛡️ Sentinel: Add security headers for development and preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -60,7 +60,17 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
+  },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos


### PR DESCRIPTION
🚨 Severity: LOW/MEDIUM (Security Enhancement)
💡 Vulnerability: Missing security headers (`X-Content-Type-Options` and `X-Frame-Options`) in Vite's local development and preview environments.
🎯 Impact: Helps prevent MIME-sniffing and clickjacking attacks. Although these are local/preview servers, having security headers parity with production ensures better local testing of security constraints.
🔧 Fix: Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to `app/vite.config.ts` under both `server.headers` and `preview.headers`.
✅ Verification: Start the Vite preview or dev server and check the response headers.

---
*PR created automatically by Jules for task [7677985672744301979](https://jules.google.com/task/7677985672744301979) started by @igormartins4*