### PR TITLE
🎨 Palette: Add keyboard focus states to custom buttons

### DIFF
--- a/app/src/components/ErrorBoundary.tsx
+++ b/app/src/components/ErrorBoundary.tsx
@@ -48,7 +48,7 @@ export class ErrorBoundary extends Component<Props, State> {
               <button
                 type="button"
                 onClick={() => window.location.reload()}
-                className="px-6 py-3 bg-brand-primary hover:bg-brand-primary/80 text-text-inverse font-semibold rounded-lg transition-colors"
+                className="px-6 py-3 bg-brand-primary hover:bg-brand-primary/80 text-text-inverse font-semibold rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2"
               >
                 Recarregar Página
               </button>

--- a/app/src/components/PopupCustomizado.tsx
+++ b/app/src/components/PopupCustomizado.tsx
@@ -195,7 +195,7 @@ export function PopupCustomizado({ parada, className, ...props }: PopupCustomiza
                   >
                     <button
                       type="button"
-                      className="w-full whitespace-normal break-words text-left"
+                      className="w-full whitespace-normal break-words text-left rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-1"
                       aria-label={`Selecionar linha ${getNomeExibicao(linha, nomeLinha)}`}
                       onClick={() => {
                         if (!linha) return;


### PR DESCRIPTION
💡 What: Added Tailwind `focus-visible` utility classes to native `<button>` elements in `PopupCustomizado` and `ErrorBoundary`.
🎯 Why: Custom buttons stripped of default styles lacked visual focus indicators, making keyboard navigation difficult for accessibility.
♿ Accessibility: Ensures keyboard users have a clear visual ring when focusing on line selection items in the map popup and the reload button on the error boundary.

---
*PR created automatically by Jules for task [12317639927130882647](https://jules.google.com/task/12317639927130882647) started by @igormartins4*