### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -68,6 +68,16 @@ export default defineConfig({
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
     },
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
   },
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(packageJson.version),


### PR DESCRIPTION
Added `X-Content-Type-Options` and `X-Frame-Options` headers to Vite's local development and preview servers to provide defense-in-depth against MIME sniffing and clickjacking, and properly simulate production constraints locally.

---
*PR created automatically by Jules for task [2462001228997762970](https://jules.google.com/task/2462001228997762970) started by @igormartins4*