### PR TITLE
🎨 Palette: Add focus-visible states to interactive elements

### DIFF
--- a/app/src/components/DisclaimerBanner.tsx
+++ b/app/src/components/DisclaimerBanner.tsx
@@ -24,6 +24,7 @@ export const contactButtonVariants = tv({
     'text-xs font-semibold transition-opacity cursor-pointer',
     'border-warning-border bg-warning-bg text-warning-text',
     'hover:opacity-80',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-warning-text focus-visible:ring-offset-2 focus-visible:ring-offset-warning-bg',
   ],
 });
 

--- a/app/src/components/MenuFooter.tsx
+++ b/app/src/components/MenuFooter.tsx
@@ -31,6 +31,7 @@ export const footerButtonVariants = tv({
   base: [
     'flex w-full items-center justify-center rounded-md border px-3 py-2',
     'text-sm font-semibold transition-colors cursor-pointer',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-1',
   ],
   variants: {
     intent: {
@@ -58,9 +59,10 @@ export const footerButtonVariants = tv({
  */
 export const creditLinkVariants = tv({
   base: [
-    'flex items-center justify-center gap-1.5 py-1 cursor-pointer',
+    'flex items-center justify-center gap-1.5 py-1 cursor-pointer rounded-sm',
     'text-xs font-bold text-text-secondary transition-colors',
     'hover:text-text-primary',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-1',
   ],
 });
 


### PR DESCRIPTION
💡 What: Added `focus-visible` Tailwind CSS classes to interactive `<a>` elements acting as buttons inside `DisclaimerBanner` and `MenuFooter`.
🎯 Why: Keyboard users previously received no visual feedback when tabbing to these elements, hindering navigation and violating WCAG 2.1 Success Criterion 2.4.7 (Focus Visible).
♿ Accessibility: Improved keyboard navigation flow and focus visibility using standard design system focus rings.

---
*PR created automatically by Jules for task [11667742473023570391](https://jules.google.com/task/11667742473023570391) started by @igormartins4*