### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to development server

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,24 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      // 🛡️ Sentinel: Defense in depth - prevent MIME sniffing and Clickjacking in dev
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      // 🛡️ Sentinel: Defense in depth - prevent MIME sniffing and Clickjacking in preview
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The local development and preview environments lacked HTTP security headers (`X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`), failing to achieve parity with the production security posture. Note that `X-Content-Type-Options` must be delivered via an actual HTTP response header (not an HTML `<meta>` tag) to be effective against MIME-sniffing attacks.
🎯 **Impact:** Exposes the development/preview environment to MIME-sniffing and Clickjacking attacks. While the risk is primarily local, maintaining defense-in-depth across all environments prevents these vulnerabilities from inadvertently slipping into production via misconfigured reverse proxies.
🔧 **Fix:** Configured Vite's `server.headers` and `preview.headers` to include the required security headers.
✅ **Verification:** Ran `pnpm build`, `pnpm test`, and `pnpm lint` to verify that the build succeeds and no functionality is impacted.

---
*PR created automatically by Jules for task [7050532409811767509](https://jules.google.com/task/7050532409811767509) started by @igormartins4*