### PR TITLE
🎨 Palette: [UX improvement] Add explicit default type="button" to Button component

### DIFF
--- a/app/src/components/ui/Button.tsx
+++ b/app/src/components/ui/Button.tsx
@@ -115,6 +115,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     rightIcon,
     loading = false,
     disabled,
+    type = 'button',
     ...props
   },
   ref,
@@ -124,6 +125,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   return (
     <button
       ref={ref}
+      type={type}
       data-slot="button"
       data-loading={loading || undefined}
       data-disabled={isDisabled || undefined}


### PR DESCRIPTION
💡 What: Added explicit `type="button"` prop as default for the reusable `Button` component in `app/src/components/ui/Button.tsx`.
🎯 Why: In React, if a generic component wrapping an HTML `<button>` element is used without a `type` prop, it inherits the default browser behavior of `type="submit"`. If such a button is placed near or within a `<form>` component (or a component that acts as one), clicking it will cause an unintended page reload or a form submission. Ensuring all reusable interactive buttons explicitly declare `type="button"` by default prevents this common UX regression.
♿ Accessibility: Ensures that form submissions are only triggered intentionally by designated submit buttons or explicitly typing them as submit.

---
*PR created automatically by Jules for task [6620132128115885686](https://jules.google.com/task/6620132128115885686) started by @igormartins4*