### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to admin buttons

### DIFF
--- a/app/src/components/admin/AdminLayout.tsx
+++ b/app/src/components/admin/AdminLayout.tsx
@@ -112,6 +112,7 @@ export function AdminLayout() {
           <button
             type="button"
             onClick={() => setActiveTab('paradas')}
+            aria-label="Selecionar aba de paradas"
             className={`px-3 py-1.5 transition-colors ${
               isParadasTab
                 ? 'bg-brand-primary text-text-inverse'
@@ -123,6 +124,7 @@ export function AdminLayout() {
           <button
             type="button"
             onClick={() => setActiveTab('linhas')}
+            aria-label="Selecionar aba de linhas"
             className={`px-3 py-1.5 transition-colors border-l border-card-border ${
               !isParadasTab
                 ? 'bg-brand-primary text-text-inverse'
@@ -149,6 +151,7 @@ export function AdminLayout() {
             onClick={handleUndo}
             disabled={!canUndo}
             title="Desfazer (Ctrl+Z)"
+            aria-label="Desfazer ação anterior"
             className={`${btnBase} border-card-border hover:enabled:bg-background-secondary`}
           >
             ↩ Desfazer
@@ -158,6 +161,7 @@ export function AdminLayout() {
             onClick={handleRedo}
             disabled={!canRedo}
             title="Refazer (Ctrl+Y)"
+            aria-label="Refazer ação desfeita"
             className={`${btnBase} border-card-border hover:enabled:bg-background-secondary`}
           >
             ↪ Refazer
@@ -170,6 +174,7 @@ export function AdminLayout() {
             type="button"
             onClick={exportParadas}
             title="Baixar paradas.ts atualizado"
+            aria-label="Exportar arquivo paradas.ts"
             className={`${btnBase} border-card-border hover:bg-background-secondary`}
           >
             ↓ paradas.ts
@@ -178,6 +183,7 @@ export function AdminLayout() {
             type="button"
             onClick={exportLinhas}
             title="Baixar linhas.ts atualizado"
+            aria-label="Exportar arquivo linhas.ts"
             className={`${btnBase} border-card-border hover:bg-background-secondary`}
           >
             ↓ linhas.ts
@@ -188,6 +194,7 @@ export function AdminLayout() {
               exportParadas();
               exportLinhas();
             }}
+            aria-label="Exportar todas as alterações"
             className="px-3 py-1.5 text-xs rounded font-semibold bg-brand-primary text-text-inverse hover:opacity-90 transition-opacity"
           >
             ↓ Exportar Tudo


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to several buttons in the `AdminLayout` component (tabs, undo, redo, and export buttons).
🎯 **Why:** To improve accessibility. Many of these buttons contain visual symbols (like arrows or emojis) or lack clear textual descriptions when navigating via screen reader. The explicit `aria-label` ensures screen readers announce the action clearly (e.g., "Exportar arquivo paradas.ts" instead of just "seta para baixo paradas ponto ts").
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Significantly improves the keyboard and screen reader navigation experience within the admin panel.

---
*PR created automatically by Jules for task [10258330997112628229](https://jules.google.com/task/10258330997112628229) started by @igormartins4*