### PR TITLE
🎨 Palette: [UX improvement] Improve SearchInput Keyboard Shortcut A11y

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -233,6 +233,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
           enterKeyHint="search"
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl+', 'Control+') : undefined
+          }
           className={cn(
             inputVariants({
               hasLeftIcon: true,
@@ -257,7 +260,10 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
             <X size={16} aria-hidden="true" />
           </button>
         ) : shortcut ? (
-          <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
+          <div
+            className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block"
+            aria-hidden="true"
+          >
             <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
               {shortcut}
             </kbd>


### PR DESCRIPTION
💡 **What:** Added `aria-keyshortcuts` to the `<input>` element in `SearchInput` when a shortcut is provided, and explicitly hid the visual `<kbd>` representation from screen readers using `aria-hidden="true"`.

🎯 **Why:** To improve accessibility for screen reader users by properly associating the keyboard shortcut directly with the input, while preventing the visual shortcut hint from being announced redundantly.

♿ **Accessibility:**
- Added `aria-keyshortcuts` mapping `⌘` to `Meta+` and `Ctrl` to `Control+`.
- Added `aria-hidden="true"` to the `<kbd>` visual container.

---
*PR created automatically by Jules for task [178114838676117034](https://jules.google.com/task/178114838676117034) started by @igormartins4*