### PR TITLE
🎨 Palette: Add accessibility attributes for SearchInput keyboard shortcut

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control+') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -257,7 +260,10 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
             <X size={16} aria-hidden="true" />
           </button>
         ) : shortcut ? (
-          <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
+          <div
+            className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block"
+            aria-hidden="true"
+          >
             <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
               {shortcut}
             </kbd>


### PR DESCRIPTION
Adds `aria-keyshortcuts` to the `<input>` element inside `SearchInput` to programmatically expose the configured keyboard shortcut to assistive technologies (converting '⌘' and 'Ctrl' to standardized ARIA 'Meta+' and 'Control+').

Also applies `aria-hidden="true"` to the visual `<kbd>` hint element to prevent screen readers from redundantly announcing the shortcut text, reducing noise and improving the navigation experience.

---
*PR created automatically by Jules for task [4945553532251106751](https://jules.google.com/task/4945553532251106751) started by @igormartins4*