### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite dev server

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options) in local development and preview environments.
🎯 **Impact:** While Vite dev server is primarily for local use, missing these headers means the development environment doesn't mirror secure production practices, potentially masking clickjacking or MIME-sniffing issues during development/testing.
🔧 **Fix:** Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to `vite.config.ts` under both `server.headers` and `preview.headers`.
✅ **Verification:** Verified by building and running tests successfully. Headers can be observed in network tab during `pnpm dev` or `pnpm preview`.

---
*PR created automatically by Jules for task [7453397710705402279](https://jules.google.com/task/7453397710705402279) started by @igormartins4*