### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing security headers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Vite development and preview servers were missing standard HTTP security headers (specifically `X-Frame-Options` and `X-Content-Type-Options`).
🎯 Impact: While primarily local, running development or preview servers without these headers can allow the app to be embedded in iframes (Clickjacking risk) or have MIME types incorrectly sniffed, masking issues that might occur in strict production environments.
🔧 Fix: Configured the `server.headers` and `preview.headers` objects in `vite.config.ts` to emit `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`.
✅ Verification: Review the `vite.config.ts` diff or inspect network requests in the browser while running `pnpm dev` or `pnpm preview`.

---
*PR created automatically by Jules for task [3005944362424548157](https://jules.google.com/task/3005944362424548157) started by @igormartins4*