### PR TITLE
🎨 Palette: Improve keyboard shortcut accessibility in SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,10 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    const ariaShortcut = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +236,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaShortcut}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +263,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What:** Added `aria-keyshortcuts` to the `<input>` element inside `SearchInput` and applied `aria-hidden="true"` to its visual `<kbd>` shortcut hint.
🎯 **Why:** When users use screen readers, visual text like `⌘K` or `Ctrl+K` may be read out confusingly if parsed textually. Hiding the visual hint and properly providing standard ARIA identifiers to the focusable element ensures screen readers announce the availability of the shortcut correctly and contextually.
♿ **Accessibility:** Translates shortcut strings (e.g., `⌘` -> `Meta+`) correctly to ARIA specs and removes redundant screen reader noise from the visual tag.

---
*PR created automatically by Jules for task [2702324547882174637](https://jules.google.com/task/2702324547882174637) started by @igormartins4*