### PR TITLE
🎨 Palette: Add ARIA keyboard shortcuts to search input

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
* 💡 What: Added `aria-keyshortcuts` to the search input, parsed correctly into ARIA identifiers (e.g., `Control` instead of `Ctrl`), and applied `aria-hidden="true"` to the visual `<kbd>` element.
* 🎯 Why: To improve keyboard accessibility and the screen reader experience. It allows screen readers to natively announce the available search shortcut while skipping the visual `<kbd>` text, avoiding redundant or confusing readouts.
* ♿ Accessibility: Fixes a missing native shortcut announcement and prevents redundant visual-only elements from cluttering screen reader output.

---
*PR created automatically by Jules for task [16647195942429521097](https://jules.google.com/task/16647195942429521097) started by @igormartins4*