### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing security headers in Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing `X-Content-Type-Options` and `X-Frame-Options` headers in local development and preview environments.
🎯 Impact: Without these headers, the application is theoretically susceptible to MIME sniffing and clickjacking, even during local testing.
🔧 Fix: Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to `server.headers` and `preview.headers` in `app/vite.config.ts`.
✅ Verification: Start the Vite dev server (`pnpm run dev`) or preview server (`pnpm run preview`) and inspect the HTTP response headers in the browser's DevTools Network tab. The headers will be present.

---
*PR created automatically by Jules for task [864188869116855782](https://jules.google.com/task/864188869116855782) started by @igormartins4*