### PR TITLE
🎨 Palette: [UX improvement] Improve keyboard shortcut accessibility

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,10 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    const ariaKeyShortcuts = shortcut
+      ? shortcut.replace(/⌘/g, 'Meta+').replace(/Ctrl/g, 'Control+')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -233,6 +237,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
           enterKeyHint="search"
+          aria-keyshortcuts={ariaKeyShortcuts}
           className={cn(
             inputVariants({
               hasLeftIcon: true,
@@ -258,7 +263,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
Translated visual shortcut props to the `aria-keyshortcuts` attribute on the search input and hid the visual `<kbd>` hint using `aria-hidden="true"`. Screen readers would previously announce the `<kbd>` tag redundantly or incorrectly. Ensures sighted users still get a visual shortcut hint while screen reader users get standardized shortcut announcements directly tied to the interactive element.

---
*PR created automatically by Jules for task [3742245574512043877](https://jules.google.com/task/3742245574512043877) started by @igormartins4*