### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite dev server

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers (`X-Content-Type-Options` and `X-Frame-Options`) on the local Vite dev/preview server. While primarily a development tool, omitting these can lead to "works on my machine" security parity issues where local testing doesn't reflect the rigid security constraints of production.
🎯 Impact: Helps catch MIME-sniffing and clickjacking vulnerabilities early during development, preventing them from unexpectedly surfacing in production environments.
🔧 Fix: Added the `headers` block to both the `server` and `preview` configurations in `app/vite.config.ts`.
✅ Verification: Ensure the dev server runs correctly and responds with the new headers on requests. Tested with `pnpm lint` and `pnpm test`.

---
*PR created automatically by Jules for task [13893838685198000968](https://jules.google.com/task/13893838685198000968) started by @igormartins4*