### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers (specifically `X-Content-Type-Options` and `X-Frame-Options`) during local development and preview serving.
🎯 Impact: Without these headers, the application is potentially vulnerable to MIME-type sniffing (leading to XSS) and clickjacking attacks (UI redressing) when served via Vite's dev/preview server.
🔧 Fix: Configured `vite.config.ts` to include `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` in both the `server` and `preview` configuration blocks.
✅ Verification: Ran `pnpm lint` and `pnpm test` successfully. Verified `vite.config.ts` was properly updated.

---
*PR created automatically by Jules for task [15056740706014860858](https://jules.google.com/task/15056740706014860858) started by @igormartins4*