### PR TITLE
🎨 Palette: Add aria-keyshortcuts and hide visual hint in SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -233,6 +233,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
           enterKeyHint="search"
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control') : undefined
+          }
           className={cn(
             inputVariants({
               hasLeftIcon: true,
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-keyshortcuts` to the input element and hid the visual `<kbd>` shortcut hint from screen readers in `SearchInput`.
🎯 Why: Prevents screen readers from double-announcing the shortcut (both visually and semantically) and maps the shortcut string to standardized ARIA key values.
♿ Accessibility: Mapped "⌘" to "Meta+" and "Ctrl" to "Control" inside `aria-keyshortcuts`, and added `aria-hidden="true"` to the decorative `<kbd>` tag.

---
*PR created automatically by Jules for task [2067797375791473246](https://jules.google.com/task/2067797375791473246) started by @igormartins4*