### PR TITLE
🛡️ Sentinel: [MEDIUM] Add basic security headers to dev server

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,26 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers in Vite dev/preview server.
🎯 Impact: Local development environments are susceptible to framing or cross-site scripting when testing application behavior locally, masking potential issues.
🔧 Fix: Configured standard headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`) for both `server.headers` and `preview.headers` in `vite.config.ts`.
✅ Verification: Tested using `pnpm dev` and `pnpm preview` locally (and verified unit tests run successfully).

---
*PR created automatically by Jules for task [13236660431290586665](https://jules.google.com/task/13236660431290586665) started by @igormartins4*