### PR TITLE
🎨 Palette: Add aria-keyshortcuts to SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -217,6 +217,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
     };
 
     const hasValue = Boolean(value);
+    const ariaShortcut = shortcut?.replace('⌘', 'Meta+').replace('Ctrl', 'Control');
 
     return (
       <div data-slot="search-input" className="relative w-full">
@@ -232,6 +233,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaShortcut}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +260,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What:** The UX enhancement added: `aria-keyshortcuts` to `SearchInput` and hid the visual `<kbd>` hint from assistive tech.
🎯 **Why:** The user problem it solves: Screen readers don't natively understand visual string shortcuts like `⌘K` printed next to an input. By explicitly providing `aria-keyshortcuts` in standard ARIA key identifier format (`Meta+K`, `Control+K`), users relying on assistive technology immediately know the shortcut. Hiding the visual hint prevents redundant and confusing reading ("Search, edit text, command K, command K").
♿ **Accessibility:**
- Added standard `aria-keyshortcuts` to the search input.
- Formatted `⌘` to `Meta+` and `Ctrl` to `Control`.
- Added `aria-hidden="true"` to `<kbd>` tag to prevent duplicate announcements.

---
*PR created automatically by Jules for task [12289952835952357209](https://jules.google.com/task/12289952835952357209) started by @igormartins4*