### PR TITLE
🛡️ Sentinel: [Medium] Add security headers to dev server

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing security headers on development and preview servers. While not immediately exploitable on localhost, it represents a deviation from production parity.
🎯 **Impact:** Exposes the dev environment to potential cross-site framing or MIME-type sniffing if shared via tunnels (e.g. ngrok), and fails to train developers against browser security interventions early.
🔧 **Fix:** Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` headers to Vite's `server` and `preview` blocks in `vite.config.ts`.
✅ **Verification:** Run `pnpm dev` and inspect the network tab headers of `localhost`. Tests and linters pass.

---
*PR created automatically by Jules for task [8718819574556713314](https://jules.google.com/task/8718819574556713314) started by @igormartins4*