### PR TITLE
🎨 Palette: improve search input keyboard shortcut accessibility

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -233,6 +233,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
           enterKeyHint="search"
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control') : undefined
+          }
           className={cn(
             inputVariants({
               hasLeftIcon: true,
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What**: Added `aria-keyshortcuts` to the search `<input>` and hid the visual `<kbd>` hint from screen readers.
🎯 **Why**: To provide native screen reader support for the keyboard shortcut while preventing double-announcement of the visual hint element.
♿ **Accessibility**: Improves semantic ARIA relationship for keyboard shortcuts, strictly mapping `⌘` to `Meta+` and `Ctrl` to `Control` per W3C specification.

---
*PR created automatically by Jules for task [13050593740402823269](https://jules.google.com/task/13050593740402823269) started by @igormartins4*