### PR TITLE
🎨 Palette: Add ARIA keyboard shortcuts to search input

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -197,6 +197,11 @@ export interface SearchInputProps extends Omit<ComponentProps<'input'>, 'size'> 
  * />
  * ```
  */
+function formatAriaKeyShortcuts(shortcut?: string): string | undefined {
+  if (!shortcut) return undefined;
+  return shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control');
+}
+
 export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
   (
     { value, onValueChange, onClear, showClear = true, onChange, shortcut, className, ...props },
@@ -205,6 +210,8 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
     const fallbackAriaLabel =
       props['aria-label'] ??
       (typeof props.placeholder === 'string' ? props.placeholder : 'Pesquisar');
+
+    const ariaKeyShortcuts = formatAriaKeyShortcuts(shortcut);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       onValueChange?.(e.target.value);
@@ -232,6 +239,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaKeyShortcuts}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +266,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Enhanced accessibility of the `SearchInput` component by formally declaring the `aria-keyshortcuts` property on the input element based on the `shortcut` prop. Adds `aria-hidden="true"` to the decorative `<kbd>` hint.

🎯 Why: Users relying on assistive technologies will now correctly hear native announcements of the keyboard shortcut when the search input receives focus, without hearing redundant or poorly-formatted character announcements from the visual `<kbd>` element.

♿ Accessibility: Native support for `aria-keyshortcuts` improves keyboard shortcut discovery for screen reader users.

---
*PR created automatically by Jules for task [3176321931905379143](https://jules.google.com/task/3176321931905379143) started by @igormartins4*