### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite dev and preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The local Vite development and preview servers were running without fundamental HTTP security headers (`X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`). This omission exposes the development and testing environments to MIME-type sniffing and clickjacking vulnerabilities.
🎯 Impact: While primarily local, developers could inadvertently expose vulnerable preview instances or falsely assume the configuration is secure for production deployments.
🔧 Fix: Configured the `headers` option within both the `server` and `preview` blocks of `vite.config.ts` to strictly enforce `nosniff` and `DENY` policies.
✅ Verification: Start the dev server (`pnpm dev`) and inspect the network response headers for any returned asset or HTML file.

A journal entry has been added to `.jules/sentinel.md` documenting this finding.

---
*PR created automatically by Jules for task [3534041700347830935](https://jules.google.com/task/3534041700347830935) started by @igormartins4*