### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing security headers in local server responses

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing HTTP Security Headers in Local Server Responses. Vite does not apply secure headers (like X-Content-Type-Options or X-Frame-Options) to its internal dev/preview servers by default.
🎯 **Impact:** Exposes local developers or reviewers using `pnpm preview` to MIME sniffing and clickjacking attacks.
🔧 **Fix:** Explicitly configured `headers` objects under `server` and `preview` configurations in `vite.config.ts`.
✅ **Verification:** Verified by running the server/preview. Headers are properly attached. Ran all tests.

---
*PR created automatically by Jules for task [8717317338965097162](https://jules.google.com/task/8717317338965097162) started by @igormartins4*