### PR TITLE
🎨 Palette: Add aria-hidden to decorative Clock icons in LinhaDetalhesModal

### DIFF
--- a/app/src/components/LinhaDetalhesModal.tsx
+++ b/app/src/components/LinhaDetalhesModal.tsx
@@ -551,7 +551,7 @@ export function LinhaDetalhesModal({
           {isLineRunningToday && passados.length > 0 && (
             <div data-slot="passed-schedules">
               <h3 className="mb-3 flex items-center gap-2 text-lg font-semibold text-text-secondary">
-                <Clock size={20} />
+                <Clock size={20} aria-hidden="true" />
                 Horários Passados ({passados.length})
               </h3>
               <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5">
@@ -574,7 +574,7 @@ export function LinhaDetalhesModal({
           {!isLineRunningToday && (
             <div data-slot="all-schedules">
               <h3 className="mb-3 flex items-center gap-2 text-lg font-semibold text-text-secondary">
-                <Clock size={20} />
+                <Clock size={20} aria-hidden="true" />
                 Todos os Horários ({todos.length})
               </h3>
               <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5">


### PR DESCRIPTION
**💡 What:** Added `aria-hidden="true"` to purely decorative `Clock` icons in the 'Horários Passados' and 'Todos os Horários' sections of `LinhaDetalhesModal`.
**🎯 Why:** Since these icons are placed immediately before text headings that clearly state their purpose (e.g., 'Horários Passados'), reading the icon as a separate interactive or informative element adds noise. Adding `aria-hidden` prevents redundant screen reader announcements and improves accessibility.
**♿ Accessibility:** Improves screen reader experience by hiding purely visual, non-interactive graphical elements that have adjacent descriptive text.

---
*PR created automatically by Jules for task [17309949698323130445](https://jules.google.com/task/17309949698323130445) started by @igormartins4*