### PR TITLE
🛡️ Sentinel: [MEDIUM] Add missing security headers to local and preview environments

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The local development and preview servers were missing fundamental HTTP security headers, specifically `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`.
🎯 **Impact:** Without these headers, applications are susceptible to MIME-type sniffing (potentially leading to XSS) and clickjacking attacks (by allowing the app to be embedded in an iframe on a malicious site). While this risk is primarily local/preview, aligning development environments with production security standards is a defense-in-depth best practice.
🔧 **Fix:** Configured the `headers` property in both the `server` and `preview` blocks of `vite.config.ts` to include the standard security headers.
✅ **Verification:** Verified by checking the `vite.config.ts` file structure and running `pnpm lint` and `pnpm test` to ensure the configuration syntax is correct and introduces no regressions.

---
*PR created automatically by Jules for task [2964304167847964964](https://jules.google.com/task/2964304167847964964) started by @igormartins4*