### PR TITLE
🎨 Palette: Add ARIA keyboard shortcut hints

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,10 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    const ariaKeyShortcuts = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl+', 'Control+')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +236,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaKeyShortcuts}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +263,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Added correct ARIA keyboard shortcut hints to the `Input.tsx` / `SearchInput` component.
🎯 Why: Enhances accessibility for screen reader users by properly conveying keyboard shortcuts (e.g., 'Meta+K') on the active input element, while simultaneously hiding the visual `<kbd>` hint from screen readers to prevent redundant or noisy announcements.
♿ Accessibility:
  - Added `aria-keyshortcuts` with standard ARIA key names to the `<input>` element.
  - Added `aria-hidden="true"` to the purely visual `<kbd>` hint.

---
*PR created automatically by Jules for task [13969618734096766532](https://jules.google.com/task/13969618734096766532) started by @igormartins4*