### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to development and preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers (`X-Content-Type-Options` and `X-Frame-Options`) on local development and preview servers.
🎯 Impact: Applications running locally without these headers could be theoretically vulnerable to MIME-sniffing attacks or clickjacking during development testing.
🔧 Fix: Added the `headers` object with `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to both the `server` and `preview` configurations in `app/vite.config.ts`.
✅ Verification: Run `pnpm run dev` or `pnpm run preview` in the `app` directory and inspect network responses to ensure the headers are present.

---
*PR created automatically by Jules for task [1961280742459336496](https://jules.google.com/task/1961280742459336496) started by @igormartins4*