### PR TITLE
🎨 Palette: Add ARIA keyshortcuts to SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,12 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    // Format shortcut for screen readers according to ARIA specification
+    // Example: "⌘K" -> "Meta+K", "Ctrl K" -> "Control+K"
+    const ariaShortcut = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control+').replace(/\s+/g, '')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +238,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaShortcut}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +265,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What:** Added `aria-keyshortcuts` attribute mapping to the active search input and hid the visual `<kbd>` shortcut hint from screen readers.
🎯 **Why:** When keyboard shortcut hints like `<kbd>⌘K</kbd>` are displayed, they might be redundantly read literal characters instead of actual hotkeys. Providing `aria-keyshortcuts` formatted properly (e.g. `Meta+K`) improves accessibility for screen reader users.
♿ **Accessibility:**
- Added `aria-keyshortcuts` calculated from the visual shortcut string (converting '⌘' to 'Meta+' and 'Ctrl' to 'Control+').
- Added `aria-hidden="true"` to the `<kbd>` tag to hide the purely visual element.

---
*PR created automatically by Jules for task [17015982054893338626](https://jules.google.com/task/17015982054893338626) started by @igormartins4*