### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing HTTP security headers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The local Vite development and preview servers were missing standard HTTP security headers, potentially exposing local testing or exposed preview environments to MIME-sniffing and clickjacking attacks.
🎯 Impact: While primarily a frontend static site, enforcing these headers prevents browsers from incorrectly guessing MIME types (nosniff) and stops the application from being loaded within an iframe (clickjacking).
🔧 Fix: Added `X-Content-Type-Options` and `X-Frame-Options` headers to both the `server` and `preview` configuration blocks in `app/vite.config.ts`.
✅ Verification: Ensure the application starts correctly using `pnpm dev` and `pnpm preview`, and verify the responses include the new headers in the network tab. All tests and builds pass successfully.

---
*PR created automatically by Jules for task [12641168699494971350](https://jules.google.com/task/12641168699494971350) started by @igormartins4*