### PR TITLE
🛡️ Sentinel: [LOW] Add security headers to local dev and preview environments

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: LOW (Enhancement)
💡 Vulnerability: Missing security headers (`X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`) in local Vite development and preview environments.
🎯 Impact: While primarily a production concern, missing headers locally can lead to discrepancies between environments and missed clickjacking or MIME-sniffing vulnerabilities during testing.
🔧 Fix: Added the security headers directly to the `server.headers` and `preview.headers` blocks in `app/vite.config.ts`.
✅ Verification: `pnpm build`, `pnpm lint`, and `pnpm test` pass successfully.

---
*PR created automatically by Jules for task [9177595574216401130](https://jules.google.com/task/9177595574216401130) started by @igormartins4*