### PR TITLE
🎨 Palette: Add aria-keyshortcuts and improve accessibility for search input

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
**💡 What:** Added `aria-keyshortcuts` to the `<input type="search">` in `SearchInput` component, formatting the visual shortcut (e.g., `⌘K` to `Meta+K`) correctly. Additionally, added `aria-hidden="true"` to the visual `<kbd>` hint.
**🎯 Why:** Purely visual shortcut hints (like `<kbd>⌘K</kbd>`) trigger screen readers to read the visual shortcut out loud, potentially interrupting navigation. To implement correctly, the visual element needs `aria-hidden="true"`, while the actual functional input should use `aria-keyshortcuts` with standard ARIA key identifiers to accurately inform screen reader users of the available shortcut.
**♿ Accessibility:** Improved semantic HTML and screen reader experience by binding the key shortcut to the active element.

---
*PR created automatically by Jules for task [7713521170694265603](https://jules.google.com/task/7713521170694265603) started by @igormartins4*