### PR TITLE
🎨 Palette: Add ARIA labels to icon-only admin buttons

### DIFF
--- a/app/src/components/admin/AdminLinhasTab.tsx
+++ b/app/src/components/admin/AdminLinhasTab.tsx
@@ -101,6 +101,7 @@ function LinhaSelector({
         type="button"
         onClick={() => setOpen((v) => !v)}
         className="w-full h-9 flex items-center gap-2 border border-input-border bg-input text-text-primary px-2.5 rounded text-sm text-left truncate hover:bg-card-hover transition-colors"
+        aria-label="Selecionar linha"
       >
         {selected ? (
           <>
@@ -376,9 +377,10 @@ export function AdminLinhasTab({
               type="button"
               onClick={handleAddLinha}
               title="Nova linha nesta categoria"
+              aria-label="Nova linha nesta categoria"
               className="px-2.5 py-1.5 text-xs rounded border border-success-border text-success-text bg-success-bg hover:opacity-90 transition-opacity"
             >
-              +
+              <span aria-hidden="true">+</span>
             </button>
             <button
               type="button"

--- a/app/src/components/admin/AdminParadasTab.tsx
+++ b/app/src/components/admin/AdminParadasTab.tsx
@@ -221,8 +221,9 @@ export function AdminParadasTab({
                   setShowDeleteConfirm(false);
                 }}
                 className="text-text-secondary hover:text-text-primary text-lg leading-none"
+                aria-label="Fechar edição"
               >
-                ×
+                <span aria-hidden="true">×</span>
               </button>
             </div>
 


### PR DESCRIPTION
🎨 Palette: Improve Admin Panel button accessibility

### 💡 What
Added `aria-label` attributes to icon-only buttons in the Admin Panel (`AdminParadasTab.tsx` and `AdminLinhasTab.tsx`) and hid the purely visual symbols (like `+` and `×`) from screen readers using `aria-hidden="true"`.

### 🎯 Why
Icon-only buttons with plain text symbols (like `+` or `×`) are often read ambiguously by screen readers (e.g., "plus" or "times"). Adding explicit `aria-label` attributes ensures screen reader users understand the exact action the button performs (e.g., "Nova linha nesta categoria" or "Fechar edição").

### ♿ Accessibility
- Added `aria-label="Fechar edição"` to the close button in the stop editing panel.
- Added `aria-label="Selecionar linha"` to the line dropdown trigger.
- Added `aria-label="Nova linha nesta categoria"` to the add line button.
- Added `aria-hidden="true"` to the visual text nodes inside these buttons to prevent redundant or confusing announcements.

---
*PR created automatically by Jules for task [16179060797322604187](https://jules.google.com/task/16179060797322604187) started by @igormartins4*