### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite dev server

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -68,6 +68,16 @@ export default defineConfig({
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
     },
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
   },
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(packageJson.version),


### PR DESCRIPTION
This PR adds standard HTTP security headers to the Vite configuration for both the development (`server`) and preview (`preview`) environments. This ensures that when testing the application locally or via preview, it behaves closer to a secure production environment, protecting against MIME-sniffing and clickjacking.

---
*PR created automatically by Jules for task [2222541506696482438](https://jules.google.com/task/2222541506696482438) started by @igormartins4*