### PR TITLE
🎨 Palette: [UX improvement] Add aria-keyshortcuts to SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    // Converts the visual shortcut to ARIA format
+    const ariaKeyShortcuts = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl+', 'Control+')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +237,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaKeyShortcuts}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +264,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
**💡 What:** Automatically applies the `aria-keyshortcuts` attribute to the `SearchInput` component based on its visual `shortcut` prop, translating keys like "⌘" to standard ARIA formats like "Meta+". Hides the visual `<kbd>` shortcut from screen readers using `aria-hidden="true"`.
**🎯 Why:** Currently, the visual shortcut hint is only rendered as a `<kbd>` element visually next to the input. Screen readers either ignore it entirely or read it as confusing trailing characters after reading the input label. By adding `aria-keyshortcuts` natively to the `input` and hiding the `<kbd>`, screen readers correctly announce the shortcut without redundancy.
**♿ Accessibility:** Enhances keyboard accessibility discovery for visually impaired users by officially mapping visual hints to standard ARIA properties.

---
*PR created automatically by Jules for task [15745848188422336792](https://jules.google.com/task/15745848188422336792) started by @igormartins4*