### PR TITLE
🛡️ Sentinel: [Medium] Add security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -68,6 +68,16 @@ export default defineConfig({
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
     },
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
   },
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(packageJson.version),


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing HTTP security headers (`X-Content-Type-Options` and `X-Frame-Options`) during local development and preview environments using Vite.
🎯 **Impact:** While local environments are generally lower risk, if a local server or preview environment is exposed (e.g., via tunnel or shared network), it could be susceptible to MIME-type sniffing and clickjacking attacks. Ensuring dev/prod parity for security headers is a best practice.
🔧 **Fix:** Explicitly configured `headers` in both the `server` and `preview` configuration blocks of `vite.config.ts` to include `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`.
✅ **Verification:** Verified that the Vite configuration accepts the headers and the production build completes successfully. Tests and linting also pass.

---
*PR created automatically by Jules for task [6716057849656928276](https://jules.google.com/task/6716057849656928276) started by @igormartins4*