### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to dev/preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The local development and preview environments managed by Vite were missing standard HTTP security headers (specifically `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`).
🎯 Impact: Without these headers, developers might inadvertently write or test code locally that relies on MIME sniffing or allows framing, creating false confidence before deployment to environments that strictly enforce these protections. This also introduces minor risks to developers running untrusted code against the local dev server.
🔧 Fix: Added explicit HTTP security headers configuration to `vite.config.ts` under both the `server` and `preview` blocks.
✅ Verification: `pnpm install`, `pnpm lint`, and `pnpm test` successfully ran. Tested the configuration locally by inspecting `vite.config.ts`.

---
*PR created automatically by Jules for task [4034447590261005333](https://jules.google.com/task/4034447590261005333) started by @igormartins4*