### PR TITLE
🎨 Palette: Improve keyboard shortcut hint accessibility for SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    // Convert visual shortcuts like '⌘K' or 'Ctrl+K' to ARIA keyshortcut format (e.g., 'Meta+K' or 'Control+K')
+    const ariaKeyShortcuts = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +237,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaKeyShortcuts}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +264,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: The UX enhancement added: `aria-keyshortcuts` explicitly set on `SearchInput` element to declare active shortcuts, and `aria-hidden="true"` on visual `<kbd>` elements to suppress duplicate screen reader announcements.
🎯 Why: The user problem it solves: Prevents screen readers from confusing users by reading decorative text elements ("command k") out of context or incorrectly, while still announcing the native shortcut ("Meta+K") correctly via standardized ARIA attributes.
♿ Accessibility: Improves accessibility for screen reader users when interacting with global search components.

---
*PR created automatically by Jules for task [7361319916751989343](https://jules.google.com/task/7361319916751989343) started by @igormartins4*