### PR TITLE
🛡️ Sentinel: [Medium] Add security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The Vite development (`server`) and preview (`preview`) environments lacked standard HTTP security headers such as `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`.
🎯 **Impact:** Missing these headers could allow MIME-type sniffing and clickjacking attacks during local testing, development, and preview, creating a discrepancy between local posture and secure production defaults.
🔧 **Fix:** Added the `headers` object explicitly to both the `server` and `preview` configuration blocks in `app/vite.config.ts`.
✅ **Verification:** Run `pnpm dev` or `pnpm preview` and inspect the HTTP response headers in the browser network tab to ensure `X-Content-Type-Options` and `X-Frame-Options` are present. Tests and linters pass successfully.

---
*PR created automatically by Jules for task [1530903725909472846](https://jules.google.com/task/1530903725909472846) started by @igormartins4*