### PR TITLE
🎨 Palette: Add accessibility attributes for keyboard shortcuts

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -217,6 +217,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
     };
 
     const hasValue = Boolean(value);
+    const ariaKeyShortcuts = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl+', 'Control+')
+      : undefined;
 
     return (
       <div data-slot="search-input" className="relative w-full">
@@ -232,6 +235,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaKeyShortcuts}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +262,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+              aria-hidden="true"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
🎨 **Palette: Improve Screen Reader Accessibility for Keyboard Shortcuts**

💡 **What:**
- Added the `aria-keyshortcuts` attribute to the main search input to programmatically expose the keyboard shortcut to assistive technologies.
- Applied `aria-hidden="true"` to the visual `<kbd>` hint element to prevent screen readers from redundantly announcing the shortcut text twice.
- Mapped visual keys (like '⌘' and 'Ctrl') to their standard ARIA counterparts ('Meta+' and 'Control+').

🎯 **Why:**
Without these attributes, screen reader users might miss the available keyboard shortcut entirely (if not announced on focus) or experience a poor UX by hearing it read aloud in a confusing or redundant way when navigating past the search container. This change ensures screen readers handle the shortcut gracefully and natively.

♿ **Accessibility:**
- Follows WAI-ARIA guidelines for keyboard shortcut announcements.
- Prevents double-announcements by explicitly hiding purely visual/decorative hints.

---
*PR created automatically by Jules for task [8255951990078033657](https://jules.google.com/task/8255951990078033657) started by @igormartins4*