### PR TITLE
🎨 Palette: Accessibility improvements for decorative elements and shortcuts

### DIFF
--- a/app/src/components/LinhaDetalhesModal.tsx
+++ b/app/src/components/LinhaDetalhesModal.tsx
@@ -383,7 +383,12 @@ export function LinhaDetalhesModal({
               borderColor: hexToRgba(linha.corHex, 0.24),
             }}
           >
-            <Bus size={24} className="drop-shadow-sm" style={{ color: linha.corHex }} />
+            <Bus
+              aria-hidden="true"
+              size={24}
+              className="drop-shadow-sm"
+              style={{ color: linha.corHex }}
+            />
           </div>
           <div className="min-w-0 flex-1">
             <h2 className="truncate text-lg font-bold leading-tight text-text-primary">

--- a/app/src/components/PopupCustomizado.tsx
+++ b/app/src/components/PopupCustomizado.tsx
@@ -170,7 +170,7 @@ export function PopupCustomizado({ parada, className, ...props }: PopupCustomiza
           <div data-slot="lines-section" className={popupLinesSectionVariants()}>
             <div className="mb-1.5 flex items-center gap-2">
               <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-internoRotas-azul-eletrico/50">
-                <Bus className="text-internoRotas-bege-areia/40" size={13} />
+                <Bus aria-hidden="true" className="text-internoRotas-bege-areia/40" size={13} />
               </div>
               <p className="text-xs font-semibold text-text-primary">
                 {parada.linhasAtendidas.length} linha

--- a/app/src/components/ui/EmptyState.tsx
+++ b/app/src/components/ui/EmptyState.tsx
@@ -180,7 +180,7 @@ export function LinesEmptyState({ category, size = 'md' }: LinesEmptyStateProps)
   return (
     <EmptyState
       size={size}
-      icon={<Bus size={iconSizes[size]} />}
+      icon={<Bus aria-hidden="true" size={iconSizes[size]} />}
       title="Nenhuma linha disponível"
       description={
         category

--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What:** Improved accessibility by managing how screen readers interpret decorative UI elements and keyboard shortcuts.
🎯 **Why:** To prevent screen readers from redundantly announcing decorative icons (`<Bus>`) and visual shortcut hints (`<kbd>`), and instead provide semantic shortcut data (`aria-keyshortcuts`) on the active element. This makes the UI significantly more pleasant and less noisy for assistive tech users.
♿ **Accessibility:** Added `aria-hidden="true"` to purely decorative elements and mapped visual shortcut strings (like `⌘K`) to standard W3C keyboard shortcut values (`Meta+K`) via the `aria-keyshortcuts` attribute.

---
*PR created automatically by Jules for task [6375998693554530654](https://jules.google.com/task/6375998693554530654) started by @igormartins4*