### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to dev/preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity**: MEDIUM

💡 **Vulnerability**: The local Vite development server and preview server were missing fundamental HTTP security headers. Specifically, `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` were absent.

🎯 **Impact**: While local servers are generally less exposed, missing these headers creates an inconsistent security posture between development and production. If a developer's local environment were accidentally exposed or targeted via DNS rebinding/CSRF from a malicious external site, the application could be vulnerable to MIME-type sniffing or Clickjacking attacks.

🔧 **Fix**: Added standard HTTP security headers to both the `server` and `preview` configuration blocks in `vite.config.ts` to enforce defense-in-depth principles early in the development lifecycle.

✅ **Verification**: Run `pnpm run build` and start the server, inspect response headers in the browser or via `curl -I localhost:5173`. Verified tests run without regression.

---
*PR created automatically by Jules for task [18047871024501758672](https://jules.google.com/task/18047871024501758672) started by @igormartins4*