### PR TITLE
🎨 Palette: Add proper ARIA attributes to keyboard shortcuts in SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,10 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    const ariaKeyShortcuts = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl+', 'Control+')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -233,6 +237,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
           enterKeyHint="search"
+          aria-keyshortcuts={ariaKeyShortcuts}
           className={cn(
             inputVariants({
               hasLeftIcon: true,
@@ -258,7 +263,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-keyshortcuts` to the `<input>` element (converting "⌘" to "Meta+" and "Ctrl" to "Control+") and added `aria-hidden="true"` to the purely visual `<kbd>` shortcut hint.
🎯 **Why:** To make the keyboard shortcuts discoverable by assistive technologies and prevent screen readers from redundantly announcing the visual character string (like "⌘K").
♿ **Accessibility:** Users relying on screen readers will now be properly informed of the input's keyboard shortcut without confusing or redundant visual announcements.

---
*PR created automatically by Jules for task [3449879976095155356](https://jules.google.com/task/3449879976095155356) started by @igormartins4*