### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to Vite dev server

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The local development and preview servers lack basic security headers, such as `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`. 
🎯 **Impact:** This can lead to MIME-sniffing and clickjacking vulnerabilities if the preview server is exposed.
🔧 **Fix:** Added `headers` configuration to both `server` and `preview` blocks in `vite.config.ts` with `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`.
✅ **Verification:** Verify that the headers are applied when running the development server (`pnpm dev`) or preview server (`pnpm preview`).

---
*PR created automatically by Jules for task [16641424416006456660](https://jules.google.com/task/16641424416006456660) started by @igormartins4*