### PR TITLE
🎨 Palette: Add aria-label to LineCard selection button

### DIFF
--- a/app/src/components/LineCard.tsx
+++ b/app/src/components/LineCard.tsx
@@ -266,6 +266,7 @@ function LineCardComponent({
         type="button"
         data-slot="select-line"
         onClick={handleCardClick}
+        aria-label={`Selecionar linha ${linha.nome}`}
         aria-pressed={isSelected}
         aria-describedby={getLineDescriptionId(linha.idRota)}
         className="w-full cursor-pointer text-left focus-visible:outline-none"


### PR DESCRIPTION
💡 **What:** Added an explicit `aria-label` to the `<button>` used for selecting a bus line in the `LineCard` component (`LineCard.tsx`).

🎯 **Why:** The `<button>` previously relied solely on its textual contents and an `aria-describedby` reference. Adding an explicit `aria-label` (e.g., "Selecionar linha [nome]") makes the primary action immediately and clearly understandable to screen reader users as soon as the element receives focus.

♿ **Accessibility:**
- Ensures screen readers announce the exact intended action of the interactive element ("Selecionar linha...").
- Maintains compliance with WCAG principles for providing text alternatives for actionable elements.

---
*PR created automatically by Jules for task [13571084009451537756](https://jules.google.com/task/13571084009451537756) started by @igormartins4*