### PR TITLE
🛡️ Sentinel: [Medium] Add security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
This PR adds standard security headers to the Vite configuration for the development and preview servers.

**Severity:** Medium
**Vulnerability:** Missing basic HTTP security headers (`X-Content-Type-Options` and `X-Frame-Options`).
**Impact:** Without these headers, the application could be vulnerable to clickjacking (if embedded in a malicious iframe) or MIME-type sniffing (where a browser misinterprets a response, potentially executing malicious scripts).
**Fix:** Explicitly configured the Vite `server.headers` and `preview.headers` to set `X-Frame-Options: DENY` and `X-Content-Type-Options: nosniff`.
**Verification:** Running `pnpm dev` or `pnpm preview` and inspecting the HTTP response headers will now show these security headers present. Tests and linters continue to pass without regression.

---
*PR created automatically by Jules for task [17725846598593291072](https://jules.google.com/task/17725846598593291072) started by @igormartins4*