### PR TITLE
🎨 Palette: Improve keyboard shortcut accessibility in SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What**: Added keyboard shortcut accessibility enhancements to the `SearchInput` component.
🎯 **Why**: To provide clear shortcut instructions to screen reader users without redundant announcements from purely visual UI elements.
♿ **Accessibility**: 
- Added `aria-keyshortcuts` to the `<input>` element with standard ARIA modifiers (e.g., `Meta+K`, `Control+K`).
- Added `aria-hidden="true"` to the purely visual `<kbd>` hint element to prevent screen readers from reading the shortcut twice.

---
*PR created automatically by Jules for task [17749171850222162477](https://jules.google.com/task/17749171850222162477) started by @igormartins4*