### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing `X-Content-Type-Options` and `X-Frame-Options` HTTP security headers in local Vite servers (`server` and `preview`).
🎯 **Impact:** If unaddressed, local development and preview environments are susceptible to MIME-type sniffing (leading to potential XSS) and clickjacking attacks via iframe embedding.
🔧 **Fix:** Configured both `server.headers` and `preview.headers` blocks in `app/vite.config.ts` to include strict `nosniff` and `DENY` rules.
✅ **Verification:** Verified headers applied during local and preview runs. Tests and lint checks pass cleanly.

---
*PR created automatically by Jules for task [5678326841261205560](https://jules.google.com/task/5678326841261205560) started by @igormartins4*