### PR TITLE
🎨 Palette: Add proper keyboard shortcut accessibility to SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-keyshortcuts` to the search input and `aria-hidden="true"` to its visual `<kbd>` shortcut hint.
🎯 Why: Screen readers announce `<kbd>` tags poorly (especially symbols like ⌘), and keyboard shortcuts should be attached to the active input using the standard ARIA attribute format (e.g., `Meta+`).
♿ Accessibility: Improves screen reader compatibility for users looking to quickly search lines using keyboard shortcuts.

---
*PR created automatically by Jules for task [3354838697004014704](https://jules.google.com/task/3354838697004014704) started by @igormartins4*