### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite dev/preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -68,6 +68,16 @@ export default defineConfig({
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
     },
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
   },
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(packageJson.version),


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing basic HTTP security headers (like `X-Content-Type-Options` and `X-Frame-Options`) on Vite's local dev and preview servers. While not critical since production usually handles this via CDN or reverse proxy, it leaves the local testing environments less secure.
🎯 **Impact:** If ignored, it could allow MIME sniffing or clickjacking vulnerabilities when someone is accessing the preview or dev servers.
🔧 **Fix:** Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` strictly to the `server.headers` and `preview.headers` configurations in `app/vite.config.ts`.
✅ **Verification:** Verify the headers are applied by running `pnpm dev` or `pnpm preview` and checking the response headers of any asset in the Network tab. Tests and linters pass without errors.

---
*PR created automatically by Jules for task [964013579757578451](https://jules.google.com/task/964013579757578451) started by @igormartins4*