### PR TITLE
🎨 Palette: [UX improvement] Add proper ARIA shortcut attributes to SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,10 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    const ariaKeyShortcuts = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +236,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaKeyShortcuts}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +263,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Added dynamic `aria-keyshortcuts` computation to `SearchInput` which parses properties like `⌘K` or `Ctrl+K` into screen-reader valid modifiers like `Meta+K` or `Control+K`. Also added `aria-hidden="true"` to the visual `<kbd>` hint.

🎯 Why: To make the `SearchInput` properly accessible to users navigating via keyboard and screen readers, ensuring that shortcuts are explicitly defined and visual hints don't get read twice.

♿ Accessibility:
- Adds correct mapping of `⌘` to `Meta+` and `Ctrl` to `Control` for semantic `aria-keyshortcuts` property.
- Prevents redundant announcements of visually displayed shortcuts on focus using `aria-hidden`.

---
*PR created automatically by Jules for task [13533249849198148948](https://jules.google.com/task/13533249849198148948) started by @igormartins4*