### PR TITLE
🎨 Palette: Improve keyboard shortcut accessibility

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,12 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    // Formata o atalho visual para o aria-keyshortcuts padrão
+    // "⌘K" -> "Meta+K", "Ctrl+K" -> "Control+K"
+    const ariaKeyshortcuts = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl+', 'Control+').replace(/\+\+/, '+') // Evita Control++K se houver + sobrando
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -230,6 +236,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           data-slot="input"
           type="search"
           value={value}
+          aria-keyshortcuts={ariaKeyshortcuts}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
           enterKeyHint="search"
@@ -258,7 +265,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+              aria-hidden="true"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What**: 
- Added dynamic formatting for keyboard shortcut hints to map to ARIA standard values (`Meta+K`, `Control+K`) instead of raw text strings (`⌘K`, `Ctrl+K`) for the `aria-keyshortcuts` attribute on the search input.
- Added `aria-hidden="true"` to the visual `<kbd>` shortcut hint tag.

🎯 **Why**: 
Screen readers will now properly announce the valid input key commands using standardized ARIA keys instead of literal symbol readings (like "command sign K"). Hiding the visual `<kbd>` tag from assistive tech prevents the screen reader from double-announcing the shortcut (once via the input's native aria attribute, and again when navigating over the visual hint).

♿ **Accessibility**:
Improves keyboard shortcut context for screen reader users by adhering to correct WCAG/ARIA specification standards for the search input component.

---
*PR created automatically by Jules for task [10673546666540893673](https://jules.google.com/task/10673546666540893673) started by @igormartins4*