### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to dev/preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The local development and preview servers lack basic HTTP security headers.
🎯 **Impact:** While local environments are naturally lower risk, missing security headers can mask issues that would occur in a secure production environment (e.g., iframes failing due to X-Frame-Options, or resources blocked by strict MIME sniffing). This is a "Defense in Depth" enhancement.
🔧 **Fix:** Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to the `server` and `preview` configuration blocks in `vite.config.ts`.
✅ **Verification:** Verified by checking `app/vite.config.ts` configuration, running linters, tests, and building the project locally.

---
*PR created automatically by Jules for task [10095902401665125054](https://jules.google.com/task/10095902401665125054) started by @igormartins4*