### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
Adds `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to the server and preview configuration in `app/vite.config.ts` to improve baseline security in non-production instances and align with defense-in-depth best practices.

---
*PR created automatically by Jules for task [5450178518156717647](https://jules.google.com/task/5450178518156717647) started by @igormartins4*