### PR TITLE
🛡️ Sentinel: [Medium] Add security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
**Severity**: Medium
**Vulnerability**: The local Vite development and preview servers were running without standard HTTP security headers, leaving them potentially vulnerable to local MIME-sniffing and clickjacking attacks.
**Impact**: An attacker could potentially embed the local preview server in a malicious frame or sniff un-typed resources, simulating an attack vector during local development or CI preview stages.
**Fix**: Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to both `server.headers` and `preview.headers` blocks in `vite.config.ts`.
**Verification**: Verified via `cat app/vite.config.ts` and successfully ran the build/lint pipelines.

---
*PR created automatically by Jules for task [7205039387128976690](https://jules.google.com/task/7205039387128976690) started by @igormartins4*