### PR TITLE
🎨 Palette: Improve screen reader accessibility for SearchInput shortcuts

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    // Parse the shortcut into standard aria-keyshortcuts format
+    const ariaKeyShortcuts = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +237,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaKeyShortcuts}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +264,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What:** Added proper ARIA keyboard shortcut attributes to the `SearchInput` component and hid the visual shortcut hint from screen readers.
🎯 **Why:** Users relying on screen readers need a programmatic way to discover keyboard shortcuts. The visual `<kbd>` element (e.g., "⌘K") is purely visual and can cause confusing duplicate or poorly pronounced announcements if not hidden. This change ensures screen readers announce the input and its corresponding standard shortcut correctly.
♿ **Accessibility:**
- Added `aria-keyshortcuts` to `<input>` with parsed keys (converting '⌘' -> 'Meta', 'Ctrl' -> 'Control').
- Added `aria-hidden="true"` to `<kbd>` hint.

---
*PR created automatically by Jules for task [13510938748430710807](https://jules.google.com/task/13510938748430710807) started by @igormartins4*