### PR TITLE
🎨 Palette: Improve screen reader accessibility for SearchInput keyboard shortcuts

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,10 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    const ariaKeyShortcuts = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +236,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaKeyShortcuts}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +263,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Added the `aria-keyshortcuts` property to `SearchInput` dynamically deriving it from the visual shortcut prop, and hid the visual `<kbd>` elements from screen readers.
🎯 Why: To prevent screen readers from redundantly announcing visual shortcut hints and instead accurately describing keyboard shortcuts with standard ARIA properties.
♿ Accessibility: Ensures correct auditory representation of standard keyboard shortcut mappings ("Meta+K", "Control+K") while avoiding double reading.

---
*PR created automatically by Jules for task [2006478654006670820](https://jules.google.com/task/2006478654006670820) started by @igormartins4*