### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The local development and preview environments lacked basic HTTP security headers. 
🎯 **Impact**: While production configurations usually handle these via CDN/Nginx, omitting them in development can lead to insecure behaviors going unnoticed or expose internal preview environments to basic web vulnerabilities (like clickjacking).
🔧 **Fix**: Added `headers` configuration to both `server` and `preview` blocks in `app/vite.config.ts`, applying `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`.
✅ **Verification**: Run `cd app && pnpm run preview` (after a build) or `pnpm run dev` and inspect the HTTP response headers in the browser network tab to ensure they are present.

---
*PR created automatically by Jules for task [10549736127198156977](https://jules.google.com/task/10549736127198156977) started by @igormartins4*