### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite dev and preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers in Vite dev/preview environments can allow clickjacking and MIME sniffing if exposed.
🎯 Impact: While usually restricted to local or ephemeral testing environments, missing security headers can still pose a risk if those environments are improperly exposed to untrusted networks.
🔧 Fix: Explicitly configured Vite's `server.headers` and `preview.headers` to include `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`.
✅ Verification: `pnpm test` and `pnpm lint` pass locally. Run Vite dev server and check network responses to verify headers.

---
*PR created automatically by Jules for task [5450561001010958290](https://jules.google.com/task/5450561001010958290) started by @igormartins4*