### PR TITLE
🎨 Palette: [a11y] Screen reader keyboard shortcut discovery

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to purely visual `<kbd>` elements indicating shortcuts, and mapped the shortcut prop to a standard ARIA string format in the `<input>` element's `aria-keyshortcuts` attribute.
🎯 Why: To improve screen reader accessibility. Redundant reading of the visual `<kbd>` tag is suppressed, while the active `<input>` field correctly announces the available keyboard shortcut to assistive technologies.
📸 Before/After: Visual presentation remains identical, but DOM attributes are enhanced for screen readers.
♿ Accessibility: Improved keyboard shortcut discoverability and reduced audio clutter.

---
*PR created automatically by Jules for task [17932683845844427061](https://jules.google.com/task/17932683845844427061) started by @igormartins4*