### PR TITLE
⚡ Bolt: Cache bus schedules into numbers via WeakMap

### DIFF
--- a/app/src/components/LineCard.tsx
+++ b/app/src/components/LineCard.tsx
@@ -16,9 +16,8 @@ import {
   findScheduleIndex,
   hexToRgba,
   minutesToTime,
-  obterHorariosLinhaNoDia,
+  obterHorariosMinutosLinhaNoDia,
   obterStatusLinha,
-  timeToMinutes,
 } from '../lib/utils';
 import type { Linha } from '../types/data.types';
 import { PrevisaoBadge } from './PrevisaoBadge';
@@ -81,14 +80,6 @@ export interface LineCardProps extends VariantProps<typeof lineCardVariants> {
  * Analisa e ordena os horários em minutos.
  * Esta operação é cara (O(N log N)) e deve ser memoizada.
  */
-function parseSchedules(horarios: string[]): number[] {
-  if (!horarios || horarios.length === 0) return [];
-
-  return horarios
-    .filter((time) => time?.includes(':'))
-    .map(timeToMinutes)
-    .sort((a, b) => a - b);
-}
 
 function calculateSchedules(schedulesInMinutes: number[], currentMinutes: number): ScheduleResult {
   if (schedulesInMinutes.length === 0) {
@@ -209,8 +200,7 @@ function LineCardComponent({
   const getSuspendedMessage = () => getLinhaNotRunningMessage(linha.categoriaDia);
 
   const schedulesInMinutes = useMemo(() => {
-    const horariosDoDia = obterHorariosLinhaNoDia(linha, now);
-    return parseSchedules(horariosDoDia);
+    return obterHorariosMinutosLinhaNoDia(linha, now);
   }, [linha, now]);
 
   // Passa schedulesInMinutes para obterStatusLinha para evitar recálculo O(N log N)

--- a/app/src/hooks/useLinhasFilter.ts
+++ b/app/src/hooks/useLinhasFilter.ts
@@ -9,7 +9,7 @@ import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'rea
 import { useDebounce } from 'use-debounce';
 import { getCurrentSpecialPeriod } from '../config/specialPeriods';
 import { getSaoPauloDayOfWeek, getSaoPauloNow } from '../lib/time';
-import { converterHoraParaMinutos, obterHorariosLinhaNoDia, obterStatusLinha } from '../lib/utils';
+import { obterHorariosMinutosLinhaNoDia, obterStatusLinha } from '../lib/utils';
 import type { CategoriaLinhas, DadosLinhas, Linha } from '../types/data.types';
 import { useAnalytics } from './useAnalytics';
 import { useCurrentTime } from './useCurrentTime';
@@ -105,10 +105,7 @@ function sortLinhas(linhas: Linha[], agora: Date): Linha[] {
   return linhas
     .map((linha) => {
       // Pré-calcula os horários uma vez por linha para evitar recomputações redundantes no comparator
-      const horariosHoje = obterHorariosLinhaNoDia(linha, agora)
-        .map(converterHoraParaMinutos)
-        .filter(Number.isFinite)
-        .sort((a, b) => a - b);
+      const horariosHoje = obterHorariosMinutosLinhaNoDia(linha, agora);
 
       const status = obterStatusLinha(linha, agora, horariosHoje);
 

--- a/app/src/hooks/usePrevisaoChegada.ts
+++ b/app/src/hooks/usePrevisaoChegada.ts
@@ -2,11 +2,7 @@ import { useMemo } from 'react';
 import { isLineAvailableToday } from '../config/specialPeriods';
 import { obterMultiplicadorTrafego } from '../config/trafegoConfig';
 import { getSaoPauloMinutesOfDay, getSaoPauloNow, toSaoPauloDate } from '../lib/time';
-import {
-  converterHoraParaMinutos,
-  converterMinutosParaHora,
-  obterHorariosLinhaNoDia,
-} from '../lib/utils';
+import { converterMinutosParaHora, obterHorariosMinutosLinhaNoDia } from '../lib/utils';
 import type { Linha } from '../types/data.types';
 import { useCurrentTime } from './useCurrentTime';
 
@@ -55,8 +51,8 @@ export function calcularPrevisaoChegada(
     return null;
   }
   const agoraSaoPaulo = toSaoPauloDate(agora);
-  const horariosSaida = obterHorariosLinhaNoDia(linha, agoraSaoPaulo);
-  if (horariosSaida.length === 0) return null;
+  const horariosSaidaMinutos = obterHorariosMinutosLinhaNoDia(linha, agoraSaoPaulo);
+  if (horariosSaidaMinutos.length === 0) return null;
 
   const horaAtualMinutos = getSaoPauloMinutesOfDay(agoraSaoPaulo);
   const multiplicadorTrafego = obterMultiplicadorTrafego(horaAtualMinutos);
@@ -90,9 +86,8 @@ export function calcularPrevisaoChegada(
   let proximoOnibus: ProximoOnibus | null = null;
   let ultimaChegadaPassada: number | null = null;
 
-  for (let i = 0; i < horariosSaida.length; i++) {
-    const saidaMinutos = converterHoraParaMinutos(horariosSaida[i]);
-    if (Number.isNaN(saidaMinutos)) continue;
+  for (let i = 0; i < horariosSaidaMinutos.length; i++) {
+    const saidaMinutos = horariosSaidaMinutos[i];
 
     let chegadaPrevistaMinutos = saidaMinutos + tempoViagemReal;
 

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -141,16 +141,19 @@ function obterChaveDiaSemana(dataAtual: Date): keyof HorariosPorDia {
  * @param dataAtual Data usada para escolher o conjunto de horários vigente.
  * @returns Lista de horários válidos para o dia, já filtrada por formato.
  */
-export function obterHorariosLinhaNoDia(linha: Linha, dataAtual: Date): string[] {
-  // Regra de negócio central: somente linhas vigentes no dia entram no motor de horários/ETA.
-  if (!isLineAvailableToday(linha.categoriaDia)) {
-    return [];
-  }
+const _horariosMinutosCache = new WeakMap<object, number[]>();
 
+/**
+ * Retorna os horários válidos da linha em minutos, utilizando WeakMap para cache
+ * com base na referência do array de horários da linha.
+ *
+ * Evita parsing O(N log N) e alocação desnecessária de strings/arrays.
+ */
+function obterArrayHorariosBruto(linha: Linha, dataAtual: Date): string[] {
   const horariosBrutos = linha.horarios as unknown;
 
   if (Array.isArray(horariosBrutos)) {
-    return horariosBrutos.filter((horario) => parseHorarioValido(horario) !== null);
+    return horariosBrutos;
   }
 
   if (!horariosBrutos || typeof horariosBrutos !== 'object') {
@@ -161,11 +164,48 @@ export function obterHorariosLinhaNoDia(linha: Linha, dataAtual: Date): string[]
   const chaveDia = obterChaveDiaSemana(dataAtual);
   const horariosDia = horariosPorDia[chaveDia];
 
-  if (!Array.isArray(horariosDia) || horariosDia.length === 0) {
+  if (!Array.isArray(horariosDia)) {
     return [];
   }
 
-  return horariosDia.filter((horario) => parseHorarioValido(horario) !== null);
+  return horariosDia;
+}
+
+export function obterHorariosMinutosLinhaNoDia(linha: Linha, dataAtual: Date): number[] {
+  if (!isLineAvailableToday(linha.categoriaDia)) {
+    return [];
+  }
+
+  const arrayBruto = obterArrayHorariosBruto(linha, dataAtual);
+  if (arrayBruto.length === 0) {
+    return [];
+  }
+
+  let horariosValidos = _horariosMinutosCache.get(arrayBruto);
+
+  if (horariosValidos) {
+    return horariosValidos;
+  }
+
+  horariosValidos = arrayBruto
+    .map((horario) => converterHoraParaMinutos(horario))
+    .filter((minutos) => Number.isFinite(minutos))
+    .sort((a, b) => a - b);
+
+  _horariosMinutosCache.set(arrayBruto, horariosValidos);
+
+  return horariosValidos;
+}
+
+export function obterHorariosLinhaNoDia(linha: Linha, dataAtual: Date): string[] {
+  // Regra de negócio central: somente linhas vigentes no dia entram no motor de horários/ETA.
+  if (!isLineAvailableToday(linha.categoriaDia)) {
+    return [];
+  }
+
+  const arrayBruto = obterArrayHorariosBruto(linha, dataAtual);
+
+  return arrayBruto.filter((horario) => parseHorarioValido(horario) !== null);
 }
 
 /**
@@ -187,12 +227,7 @@ export function obterStatusLinha(
     return { id: 'NAO_CIRCULA_HOJE', texto: 'Não circula hoje', cor: 'danger' };
   }
 
-  const horariosHoje =
-    horariosPreCalculados ??
-    obterHorariosLinhaNoDia(linha, dataAtual)
-      .map((horario) => converterHoraParaMinutos(horario))
-      .filter((minutos) => Number.isFinite(minutos))
-      .sort((a, b) => a - b);
+  const horariosHoje = horariosPreCalculados ?? obterHorariosMinutosLinhaNoDia(linha, dataAtual);
 
   if (horariosHoje.length === 0) {
     return {


### PR DESCRIPTION
💡 What: Memoized schedule parsing in `obterHorariosMinutosLinhaNoDia` using a `WeakMap`.
🎯 Why: Parsing strings to integers and sorting them takes O(N log N) time and happens on every render loop across several UI components like `LineCard`.
📊 Impact: Reduced sorting overhead by caching derived array mapping, eliminating repetitive array traversals across the codebase.
🔬 Measurement: Verify cache lookups trigger efficiently instead of invoking string manipulation by reading `LineCard` and `usePrevisaoChegada` outputs.

---
*PR created automatically by Jules for task [15153779697991350371](https://jules.google.com/task/15153779697991350371) started by @igormartins4*