### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to Vite dev and preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,26 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+      'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+      'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The local development and preview environments lacked standard HTTP security headers, leaving them potentially more susceptible to clickjacking, MIME-sniffing, and XSS during local testing.
🎯 Impact: While this is a local environment issue, enforcing security headers early in the development lifecycle creates a defense-in-depth approach and ensures that local testing accurately reflects security constraints.
🔧 Fix: Added `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, and `Strict-Transport-Security` headers to the `server.headers` and `preview.headers` blocks in `vite.config.ts`.
✅ Verification: Ran `pnpm build`, `pnpm lint`, and tests successfully in the `app` directory. Changes have been visually verified using `tail` on the config file.

---
*PR created automatically by Jules for task [4193778850603947450](https://jules.google.com/task/4193778850603947450) started by @igormartins4*