### PR TITLE
🎨 Palette: Add aria-keyshortcuts and hide visual hint

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,10 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    const ariaKeyshortcuts = shortcut
+      ? shortcut.replace(/⌘/, 'Meta+').replace(/Ctrl\+/, 'Control+')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +236,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaKeyshortcuts}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +263,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What:** Added `aria-keyshortcuts` attribute to the search input, parsing standard keyboard strings (e.g. converting "⌘" to "Meta+" and "Ctrl+" to "Control+"). Hide the visual `<kbd>` elements using `aria-hidden="true"`.
🎯 **Why:** To prevent redundant and potentially confusing screen reader announcements of decorative keyboard symbols like "⌘K", while properly communicating the keyboard shortcut via standard ARIA specifications.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** The input now properly binds DOM Level 3 key identifiers so screen readers can correctly associate the search functionality with its keyboard shortcut.

---
*PR created automatically by Jules for task [16972842966280905112](https://jules.google.com/task/16972842966280905112) started by @igormartins4*