### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The local development and preview environments were missing basic HTTP security headers. While these are typically handled by production web servers or CDNs, missing them in preview/dev environments can occasionally lead to security oversights if the preview server is temporarily exposed, or if developers are testing framing/clickjacking mitigations locally.
🎯 **Impact:** Prevents MIME-type sniffing (forcing the browser to honor the declared Content-Type) and mitigates Clickjacking attacks by preventing the site from being framed.
🔧 **Fix:** Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to `server.headers` and `preview.headers` in `vite.config.ts`.
✅ **Verification:** Run `pnpm dev` or `pnpm preview` and inspect the network response headers in the browser's developer tools. The tests and linters continue to pass without regressions.

---
*PR created automatically by Jules for task [15899786075622909021](https://jules.google.com/task/15899786075622909021) started by @igormartins4*