### PR TITLE
🎨 Palette: Add ARIA keyshortcuts to SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl+', 'Control+') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What**: Added `aria-keyshortcuts` explicitly to the `<input type="search">` tag, translating `⌘` to `Meta+` and `Ctrl+` to `Control+` for screen readers. Also applied `aria-hidden="true"` on the visual `<kbd>` elements.
🎯 **Why**: When visually displaying keyboard shortcuts in the UI using `<kbd>` tags (like `⌘K`), screen readers often read the text redundantly or unintelligibly. Hiding the visual aspect and applying proper semantic ARIA roles on the active element provides a seamless experience for visually impaired users.
📸 **Before/After**: The visual UI is unchanged, preserving the existing design patterns.
♿ **Accessibility**: Prevents duplicate shortcut announcements by screen readers and properly maps shortcuts to standard W3C keyshortcut semantics.

---
*PR created automatically by Jules for task [7090256466798776698](https://jules.google.com/task/7090256466798776698) started by @igormartins4*