### PR TITLE
🛡️ Sentinel: [Medium] Add security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers in Vite configuration (`server` and `preview` blocks), leaving local development and preview environments vulnerable to MIME-type sniffing and Clickjacking attacks.
🎯 Impact: Attackers could potentially exploit MIME sniffing or frame the application maliciously if these environments are exposed or tested directly.
🔧 Fix: Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to both `server.headers` and `preview.headers` in `app/vite.config.ts`.
✅ Verification: Ran `pnpm install`, `pnpm lint`, and `pnpm test` in the `app` directory to ensure no regressions. Verified the Vite config syntax is correct.

---
*PR created automatically by Jules for task [3734225293798660122](https://jules.google.com/task/3734225293798660122) started by @igormartins4*