### PR TITLE
🎨 Palette: [a11y improvement] Improve SearchInput screen reader shortcuts

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-keyshortcuts` to the `SearchInput` component and hid the visual `<kbd>` shortcut hint from screen readers.
🎯 Why: Enhances accessibility for screen reader users by natively announcing the available keyboard shortcuts in a standard format (e.g., "Meta+K") instead of reading visual shorthand out of context.
📸 Before/After: Visuals remain unchanged. Screen readers now correctly interpret the shortcut without redundant text.
♿ Accessibility: 
- Maps '⌘' and 'Ctrl' to standardized W3C modifiers ('Meta+' and 'Control').
- Uses `aria-hidden="true"` to hide the visual `<kbd>` elements.
- Uses `aria-keyshortcuts` to correctly bind the hint to the active input.

---
*PR created automatically by Jules for task [11660091161143357848](https://jules.google.com/task/11660091161143357848) started by @igormartins4*