### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers in local development and preview environments. This could allow for MIME-sniffing or clickjacking attacks (e.g. framing the application on an untrusted site).
🎯 Impact: While primarily affecting dev/preview environments since production headers are typically set by the host, lacking these headers means the application behaves differently from production, which may hide iframe or MIME-type issues until deployed.
🔧 Fix: Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to both `server.headers` and `preview.headers` in `app/vite.config.ts`.
✅ Verification: Ran `pnpm build`, `pnpm lint`, and `pnpm test` successfully. Verified `app/vite.config.ts` changes.

---
*PR created automatically by Jules for task [737082429983263833](https://jules.google.com/task/737082429983263833) started by @igormartins4*