### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The development and preview servers in Vite were not setting critical security headers (`X-Content-Type-Options` and `X-Frame-Options`). This could potentially expose the development environment to clickjacking or MIME-sniffing attacks if malicious files were served or the server was embedded in an iframe.
🎯 Impact: While usually protected by a production proxy, having the headers missing in development/preview exposes local environments to risks and fails to provide defense in depth.
🔧 Fix: Explicitly added these headers to the `server.headers` and `preview.headers` configuration blocks in `app/vite.config.ts`.
✅ Verification: Ensure the server serves these headers by running `pnpm dev` and inspecting the network tab, or check the `vite.config.ts` configuration directly. Tests pass without regression.

---
*PR created automatically by Jules for task [5058702798473296832](https://jules.google.com/task/5058702798473296832) started by @igormartins4*