### PR TITLE
🎨 Palette: [a11y] Improve screen reader support for keyboard shortcuts

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,12 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    // Convert visual shortcut to ARIA standard format
+    // "⌘K" -> "Meta+K", "Ctrl+K" -> "Control+K"
+    const ariaKeyShortcuts = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace(/Ctrl/i, 'Control')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +238,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaKeyShortcuts}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +265,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What:** Added `aria-keyshortcuts` to the main `<input>` element in `SearchInput` to accurately declare keyboard shortcut bindings (converting `⌘K` to `Meta+K`, etc.), and added `aria-hidden="true"` to the visual `<kbd>` element to prevent it from being redundantly announced by screen readers when focusing the input.

🎯 **Why:** To improve the accessibility of keyboard shortcuts for screen reader users. Previously, the input had no programmatic relationship with the visual keyboard shortcut indicator. When a user focused the input, the visual hint wasn't clearly announced as a shortcut, and standard shortcut key commands weren't explicitly described.

♿ **Accessibility:**
* Programmatically associates standard key combinations to the element via `aria-keyshortcuts`.
* Cleans up screen reader output by hiding purely visual components (like the `<kbd>` tag inside the input wrapper) from the accessibility tree, eliminating confusion and double-announcements.

---
*PR created automatically by Jules for task [2215274754267062938](https://jules.google.com/task/2215274754267062938) started by @igormartins4*