### PR TITLE
🎨 Palette: Add proper aria-keyshortcuts to Input for screen reader support

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    // Converte o atalho visual para o formato esperado pelo aria-keyshortcuts
+    const ariaKeyShortcut = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl+', 'Control+')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +237,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaKeyShortcut}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +264,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Converted the visual keyboard shortcut hint (e.g., `⌘K`) into a semantic, screen-reader-friendly `aria-keyshortcuts` property (e.g., `Meta+K`) on the `<input>` element. Also added `aria-hidden=\"true\"` to the visual `<kbd>` elements to prevent redundant announcements.
🎯 Why: To ensure keyboard shortcut hints are correctly communicated to users navigating via screen readers while keeping the visual component intact.
♿ Accessibility: Improves accessibility by decoupling visual hints from semantic roles and leveraging standard ARIA modifiers.

---
*PR created automatically by Jules for task [11226895595662640861](https://jules.google.com/task/11226895595662640861) started by @igormartins4*