### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to development and preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Missing HTTP security headers (`X-Content-Type-Options`, `X-Frame-Options`) on development and preview servers.
🎯 **Impact**: Without these headers, the application could be vulnerable to MIME-sniffing and Clickjacking attacks during local development or preview testing.
🔧 **Fix**: Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to both the `server` and `preview` configurations in `vite.config.ts`.
✅ **Verification**: Ran `pnpm test` and `pnpm lint`. Confirmed the Vite configuration applies the headers correctly.

---
*PR created automatically by Jules for task [12348466510643706975](https://jules.google.com/task/12348466510643706975) started by @igormartins4*