### PR TITLE
🎨 Palette: Improve accessibility of keyboard shortcut hints in Input component

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -233,6 +233,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
           enterKeyHint="search"
+          aria-keyshortcuts={shortcut?.replace('⌘', 'Meta+').replace('Ctrl', 'Control')}
           className={cn(
             inputVariants({
               hasLeftIcon: true,
@@ -258,7 +259,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
### 💡 What
Added `aria-keyshortcuts` to the interactive search input and hid the visual `<kbd>` shortcut hint from screen readers.

### 🎯 Why
When a keyboard shortcut is visually indicated using a `<kbd>` tag inside or next to an interactive element, screen readers often read the raw text (e.g., "command K"), which can be redundant or confusing if not properly associated with the action. By explicitly mapping the shortcut string to standard ARIA formats (e.g., "⌘K" to "Meta+K") and setting `aria-keyshortcuts` on the `<input>` itself, we ensure assistive technologies announce the available shortcut contextually. Simultaneously, hiding the visual-only `<kbd>` tag with `aria-hidden="true"` removes duplicate and unhelpful announcements.

### 📸 Before/After
N/A (Visual appearance is unchanged; changes are strictly DOM semantic).

### ♿ Accessibility
- Prevents redundant announcements of visual keyboard hints.
- Links standard `aria-keyshortcuts` strings to the active input control.

---
*PR created automatically by Jules for task [15526714759590877281](https://jules.google.com/task/15526714759590877281) started by @igormartins4*