### PR TITLE
🛡️ Sentinel: Add security headers to Vite dev and preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers (X-Content-Type-Options, X-Frame-Options) on the development and preview servers, increasing the risk of MIME-type confusion and Clickjacking when interacting with these environments.
🎯 Impact: While less critical in development, lack of these headers means the local environment does not mirror production security, and preview environments could potentially be exploited if exposed.
🔧 Fix: Added `headers` configuration to both `server` and `preview` blocks in `app/vite.config.ts` enforcing `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`.
✅ Verification: Run `pnpm build` and verify that the preview server includes these headers in the HTTP response. Tests (`pnpm lint`, `pnpm test`) pass without issue.

---
*PR created automatically by Jules for task [11570767867128220461](https://jules.google.com/task/11570767867128220461) started by @igormartins4*