### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -68,6 +68,16 @@ export default defineConfig({
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
     },
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
   },
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(packageJson.version),


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing HTTP security headers in development and preview environments. While these are primarily build-time environments, exposing them without standard protections (like MIME sniffing prevention and framing denial) fails to enforce secure-by-default behavior locally and might mask issues if the app was unintentionally susceptible to framing.
🎯 **Impact:** Malicious actors could theoretically attempt MIME-sniffing or clickjacking against developers running the local dev server or preview builds, although the practical risk is lower than in production.
🔧 **Fix:** Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` headers to the `server` and `preview` blocks in `app/vite.config.ts`.
✅ **Verification:** Run `pnpm dev` or `pnpm preview` and inspect the network requests for the application document; the response headers will now include these protections. Tests and linters pass successfully.

---
*PR created automatically by Jules for task [10115519121560007550](https://jules.google.com/task/10115519121560007550) started by @igormartins4*