### PR TITLE
🛡️ Sentinel: Add HTTP security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing HTTP security headers in Vite development and preview environments. While production deployments usually configure this at the edge/CDN level, missing these locally can lead to misconfigurations or inconsistent security environments.
🎯 **Impact:** Prevents MIME-type sniffing (`nosniff`) and protects against clickjacking attacks (`DENY`) by explicitly forbidding the application from being framed.
🔧 **Fix:** Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to the `server.headers` and `preview.headers` configuration blocks in `app/vite.config.ts`.
✅ **Verification:** Run `pnpm dev` or `pnpm preview` and inspect the network requests to verify the new headers are applied. Tested locally and passes all linters and tests.

---
*PR created automatically by Jules for task [5177663386058176321](https://jules.google.com/task/5177663386058176321) started by @igormartins4*