### PR TITLE
🎨 Palette: Improve accessibility of search input keyboard shortcut

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -217,6 +217,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
     };
 
     const hasValue = Boolean(value);
+    const ariaKeyShortcuts = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control')
+      : undefined;
 
     return (
       <div data-slot="search-input" className="relative w-full">
@@ -232,6 +235,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaKeyShortcuts}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +262,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
This PR enhances the accessibility of the `SearchInput` component. Screen readers often struggle with visual keyboard shortcut indicators (like `⌘K`), either announcing them poorly or redundantly when focus lands on the input.

This change:
1. Formats the user-facing `shortcut` string into a standard, screen-reader-friendly `aria-keyshortcuts` format (e.g., mapping `⌘` to `Meta+` and `Ctrl` to `Control`).
2. Applies the formatted string directly to the `<input>` element.
3. Hides the visual `<kbd>` hint from the accessibility tree using `aria-hidden="true"` to prevent double-announcement, suppressing the associated Biome linter rule as this is purely a decorative visual hint.

---
*PR created automatically by Jules for task [7173333181028962413](https://jules.google.com/task/7173333181028962413) started by @igormartins4*