### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers in Vite dev/preview server configurations.
🎯 Impact: Local development environments lack basic defense in depth against cross-site scripting (XSS), MIME sniffing, and clickjacking attacks.
🔧 Fix: Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` headers to `server` and `preview` configuration blocks in `vite.config.ts`.
✅ Verification: Tested locally by verifying the Vite proxy includes these headers in responses. Validated with `pnpm lint` and `pnpm test`.

---
*PR created automatically by Jules for task [988654479012458758](https://jules.google.com/task/988654479012458758) started by @igormartins4*