### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,26 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers in Vite configuration.
🎯 Impact: Without headers like `X-Frame-Options: DENY` and `X-Content-Type-Options: nosniff`, the application (even in development/preview environments) might be vulnerable to basic clickjacking or MIME-type sniffing attacks if exposed or tested improperly.
🔧 Fix: Configured Vite's `server.headers` and `preview.headers` to include a standard set of secure HTTP headers, offering an additional layer of defense-in-depth during local testing.
✅ Verification: `cat app/vite.config.ts` confirms headers are properly applied in both blocks. `pnpm run test` and `pnpm lint` pass successfully.

---
*PR created automatically by Jules for task [9844502203879769325](https://jules.google.com/task/9844502203879769325) started by @igormartins4*