### PR TITLE
🎨 Palette: Adicionar aria-keyshortcuts em SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,14 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    const ariaShortcut = shortcut
+      ? shortcut
+          .replace('⌘', 'Meta+')
+          .replace('Ctrl', 'Control')
+          .replace('Shift', 'Shift')
+          .replace('Alt', 'Alt')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +240,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaShortcut}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +267,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
Added standard ARIA accessibility attributes to the `SearchInput` component. Visual hints are now hidden from screen readers using `aria-hidden="true"`, while the actual input correctly maps visual shortcuts into W3C standard ARIA identifiers for the `aria-keyshortcuts` attribute, improving semantic clarity and preventing duplicate announcements.

---
*PR created automatically by Jules for task [1444815260146744893](https://jules.google.com/task/1444815260146744893) started by @igormartins4*