### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,6 +61,11 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      // 🛡️ Sentinel: Prevent MIME type sniffing and clickjacking attacks
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
@@ -100,6 +105,13 @@ export default defineConfig({
           return 'vendor-misc';
         },
       },
+    },
+  },
+  preview: {
+    headers: {
+      // 🛡️ Sentinel: Prevent MIME type sniffing and clickjacking attacks in preview
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
 });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers in development/preview server
🎯 Impact: Local or preview servers could be vulnerable to clickjacking or MIME-type sniffing if exposed
🔧 Fix: Added X-Content-Type-Options and X-Frame-Options to both `server` and `preview` blocks in Vite config
✅ Verification: Ran `pnpm test` and `pnpm lint`. Confirmed headers via config inspection.

---
*PR created automatically by Jules for task [8485257515367214684](https://jules.google.com/task/8485257515367214684) started by @igormartins4*