### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to development servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,28 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
+      'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.tile.openstreetmap.org; connect-src 'self' https://*.tile.openstreetmap.org",
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
+      'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.tile.openstreetmap.org; connect-src 'self' https://*.tile.openstreetmap.org",
     },
   },
   define: {


### PR DESCRIPTION
Added standard HTTP security headers to Vite's local dev (`server`) and preview (`preview`) environments to improve the defense-in-depth posture during development. The headers include a basic CSP tailored to allow the application's OpenStreetMap tile dependency.

🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers in local development servers.
🎯 Impact: While these are development servers, enforcing headers locally helps catch CSP violations and potential XSS vectors early before production deployment.
🔧 Fix: Configured `server.headers` and `preview.headers` in `app/vite.config.ts`.
✅ Verification: Ensure the application runs locally and maps still load correctly without CSP errors in the browser console.

---
*PR created automatically by Jules for task [351999924615976230](https://jules.google.com/task/351999924615976230) started by @igormartins4*