### PR TITLE
🎨 Palette: Improve keyboard shortcut accessibility

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    // Formata o atalho para ser lido corretamente pelo leitor de tela (aria-keyshortcuts)
+    const ariaShortcut = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +237,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaShortcut}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +264,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Calculates `ariaShortcut` by converting symbols to standardized ARIA key identifiers (e.g. '⌘' to 'Meta+' and 'Ctrl' to 'Control') and applies it via `aria-keyshortcuts` to the `<input>` element. Applies `aria-hidden="true"` to the visual `<kbd>` hint.
🎯 Why: Screen readers would previously either ignore the shortcut or read it redundantly/improperly as it was only provided visually. Explicit ARIA properties improve correct screen reader announcements.
📸 Before/After: Visual UI remains unchanged.
♿ Accessibility: Ensures the keyboard shortcut is properly broadcast via the standard `aria-keyshortcuts` property directly on the focused, active input element. Prevents redundant announcements of visual elements.

---
*PR created automatically by Jules for task [6215658871512242773](https://jules.google.com/task/6215658871512242773) started by @igormartins4*