### PR TITLE
🎨 Palette: Improve screen reader experience for keyboard shortcuts

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,10 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    const ariaKeyShortcuts = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -233,6 +237,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
           enterKeyHint="search"
+          aria-keyshortcuts={ariaKeyShortcuts}
           className={cn(
             inputVariants({
               hasLeftIcon: true,
@@ -258,7 +263,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What:** Added the `aria-keyshortcuts` attribute to the search input and hid the visual `<kbd>` hint using `aria-hidden="true"`.
🎯 **Why:** To prevent screen readers from reading redundant keyboard shortcuts disconnected from the input element, making the search feature more accessible.
♿ **Accessibility:** Translates standard Mac/PC keyboard modifier string values (`⌘`, `Ctrl`) into valid ARIA key names (`Meta+`, `Control`) and associates them directly with the input, allowing screen reader users to quickly discover the shortcut.

---
*PR created automatically by Jules for task [9942483837191600899](https://jules.google.com/task/9942483837191600899) started by @igormartins4*