### PR TITLE
🛡️ Sentinel: [MEDIUM] Add security headers to dev and preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing standard HTTP security headers (like X-Content-Type-Options and X-Frame-Options) in local development and preview environments.
🎯 Impact: While production environments may configure these headers via CDN or reverse proxy, omitting them in local and preview environments leaves developers and QA exposed to basic MIME-sniffing and clickjacking attacks while testing, and fails to establish secure-by-default behavior across the SDLC.
🔧 Fix: Explicitly added `headers` configurations to the `server` and `preview` blocks in `app/vite.config.ts` setting `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY`.
✅ Verification: Start the local dev server using `pnpm dev` and inspect the HTTP response headers in the browser network tab, or run the app's test suite to ensure the Vite configuration remains valid.

---
*PR created automatically by Jules for task [11818286303282749443](https://jules.google.com/task/11818286303282749443) started by @igormartins4*