### PR TITLE
🎨 Palette: Improve accessibility for keyboard shortcut hints

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -233,6 +233,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
           enterKeyHint="search"
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control') : undefined
+          }
           className={cn(
             inputVariants({
               hasLeftIcon: true,
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-keyshortcuts` to the search input element, and `aria-hidden="true"` to the purely visual `<kbd>` shortcut hint.
🎯 Why: Prevents screen readers from redundantly announcing the visual keyboard hint as a separate interactive element, while correctly associating the shortcut key combination with the input field itself for assistive technologies.
📸 Before/After: Visuals unchanged. Screen reader experience improved.
♿ Accessibility: Improved keyboard shortcut semantics per ARIA spec.

---
*PR created automatically by Jules for task [14402716149540455628](https://jules.google.com/task/14402716149540455628) started by @igormartins4*