### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to Vite dev and preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,26 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      // 🛡️ Sentinel: Prevent MIME type sniffing
+      'X-Content-Type-Options': 'nosniff',
+      // 🛡️ Sentinel: Prevent clickjacking attacks by disallowing framing
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      // 🛡️ Sentinel: Prevent MIME type sniffing
+      'X-Content-Type-Options': 'nosniff',
+      // 🛡️ Sentinel: Prevent clickjacking attacks by disallowing framing
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing local security headers (`X-Content-Type-Options`, `X-Frame-Options`) on the Vite dev and preview servers, leading to potential Clickjacking and MIME-type sniffing risks during local testing/preview phases.
🎯 **Impact:** Prevents potential Clickjacking and MIME-type sniffing attacks. Ensures local development and preview environments closely mirror a secure production configuration.
🔧 **Fix:** Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to `server.headers` and `preview.headers` in `app/vite.config.ts`. Added inline comments explaining the security enhancements.
✅ **Verification:** Run `cd app && pnpm run build` and inspect the configuration file `app/vite.config.ts`. Run the development server and verify headers via network tab if desired. All tests passed.

---
*PR created automatically by Jules for task [2908439114175941933](https://jules.google.com/task/2908439114175941933) started by @igormartins4*