### PR TITLE
🎨 Palette: Improve keyboard shortcut accessibility

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace(/Ctrl\s*/, 'Control+') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
🎨 Palette: Improve keyboard shortcut accessibility

💡 What: Added `aria-keyshortcuts` to the search input and applied `aria-hidden="true"` to the visual `<kbd>` hint.
🎯 Why: Prevents redundant screen reader announcements of the visual hint, while natively exposing the keyboard shortcut shortcut string to assistive technologies.
♿ Accessibility: Ensures that screen reader users are properly informed of the keyboard shortcut via the correct ARIA attribute, while reducing visual clutter for ATs.

---
*PR created automatically by Jules for task [3755223007618566174](https://jules.google.com/task/3755223007618566174) started by @igormartins4*