### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers to development and preview servers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,26 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      // Security: Prevent MIME-sniffing
+      'X-Content-Type-Options': 'nosniff',
+      // Security: Prevent clickjacking attacks
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      // Security: Prevent MIME-sniffing
+      'X-Content-Type-Options': 'nosniff',
+      // Security: Prevent clickjacking attacks
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers (X-Content-Type-Options, X-Frame-Options) on local and preview servers could allow MIME-sniffing or clickjacking attacks if environments are exposed or during testing.
🎯 Impact: Reduces defense-in-depth posture.
🔧 Fix: Configured Vite `server` and `preview` options to automatically inject `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` headers with explanatory comments.
✅ Verification: Ran `pnpm lint` and tests, confirmed headers exist in `vite.config.ts`.

---
*PR created automatically by Jules for task [9281825373361761363](https://jules.google.com/task/9281825373361761363) started by @igormartins4*