### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,24 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.tile.openstreetmap.org; connect-src 'self' ws: wss: https://*.tile.openstreetmap.org;",
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.tile.openstreetmap.org; connect-src 'self' https://*.tile.openstreetmap.org;",
     },
   },
   define: {


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The Vite development and preview servers lack basic HTTP security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Content-Security-Policy`), which can lead to MIME-sniffing, Clickjacking, and unauthorized resource loading in the local/preview environment.
🎯 **Impact**: While these headers primarily affect development and preview environments, enforcing them locally ensures that developers catch CSP violations and secure resource loading issues before production deployment. It also hardens the preview server against basic web vulnerabilities.
🔧 **Fix**: Added `server.headers` and `preview.headers` to `app/vite.config.ts`. The CSP is configured to explicitly allow Vite's HMR websockets (`ws:`, `wss:`) for the dev server, and allows OpenStreetMap tiles (`https://*.tile.openstreetmap.org`) in `img-src` and `connect-src` to ensure map functionality is not broken.
✅ **Verification**: Run `cd app && pnpm lint && pnpm test` to verify no regressions in the build process. Starting `pnpm dev` or `pnpm preview` and inspecting the network responses will confirm the presence of the headers.

---
*PR created automatically by Jules for task [2153236726022655647](https://jules.google.com/task/2153236726022655647) started by @igormartins4*