### PR TITLE
🎨 Palette: Add ARIA keyshortcuts to SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,10 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    const ariaKeyShortcuts = shortcut
+      ? shortcut.replace('⌘', 'Meta+').replace('Ctrl', 'Control').replace('++', '+')
+      : undefined;
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +236,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaKeyShortcuts}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +263,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What**: Added `aria-keyshortcuts` to the `SearchInput` element to map the visual keyboard shortcuts (e.g., `⌘K`, `Ctrl+K`) to standard screen reader semantics (`Meta+K`, `Control+K`). Additionally, marked the visual `<kbd>` hints with `aria-hidden="true"`.
🎯 **Why**: Previously, screen readers would blindly announce the text inside the input or the characters like `⌘` out of context, without programmatically associating the search shortcut to the input itself. This ensures screen reader users have immediate access to the standard keyboard shortcuts without redundancy.
📸 **Before/After**: The visual appearance remains exactly the same, but the underlying DOM elements are semantically sound.
♿ **Accessibility**: Prevents redundant readout of visual decorators by hiding them from accessibility APIs, and binds proper ARIA shortcuts directly to the focusable input element.

---
*PR created automatically by Jules for task [14778011685576801278](https://jules.google.com/task/14778011685576801278) started by @igormartins4*