### PR TITLE
🎨 Palette: Add keyboard shortcut accessibility hints

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl+', 'Control+') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What:** Added proper ARIA keyboard shortcut semantics to the `SearchInput` component.
🎯 **Why:** To ensure screen reader users are correctly informed about the available keyboard shortcut (like ⌘K or Ctrl+K) when the search input receives focus, while preventing redundant announcements of the visual `<kbd>` hint.
📸 **Before/After:** No visual changes.
♿ **Accessibility:**
- Added `aria-keyshortcuts` to the `<input>` element with standard identifiers (`Meta+K`, `Control+K`).
- Applied `aria-hidden="true"` to the purely visual `<kbd>` hint.

---
*PR created automatically by Jules for task [10725069271889334914](https://jules.google.com/task/10725069271889334914) started by @igormartins4*