### PR TITLE
🎨 Palette: [UX improvement] Improve SearchInput accessibility with aria-keyshortcuts

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl+', 'Control+') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Added the `aria-keyshortcuts` attribute to the search input and applied `aria-hidden="true"` to the visual `<kbd>` shortcut hint.
🎯 Why: Screen readers would redundantly read the visual hint `<kbd>⌘K</kbd>` and wouldn't understand `⌘` natively. This correctly associates the parsed shortcut using ARIA standards directly to the input field, creating a cleaner auditory experience.
📊 Impact: Improved accessibility for screen reader users trying to utilize or understand keyboard shortcuts.
🔬 Measurement: Verified the correct generation of ARIA key identifiers (e.g. `Meta+K`, `Control+K`) using simple unit tests, and verified visually using `cat`.
📸 Before/After: Visual `<kbd>` hint was previously announced, and `SearchInput` lacked `aria-keyshortcuts`. Now, the `<kbd>` is hidden from screen readers, and the input properly announces its shortcut.
♿ Accessibility: Directly addresses redundant screen reader announcements and standardizes ARIA keyboard shortcut definitions.

---
*PR created automatically by Jules for task [9603176639435319660](https://jules.google.com/task/9603176639435319660) started by @igormartins4*