### PR TITLE
🎨 Palette: [UX improvement] Add accessible keyboard shortcut hint to SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl+', 'Control+') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-keyshortcuts` to the `<input>` element in `SearchInput` to explicitly communicate keyboard shortcuts (mapping `⌘` to `Meta+` and `Ctrl+` to `Control+` automatically). Additionally, added `aria-hidden="true"` to the visual `<kbd>` hint element to prevent screen readers from redundantly announcing the visual hint.
🎯 Why: Visual keyboard shortcut hints without proper ARIA semantics cause redundant screen reader announcements and fail to expose the shortcut programmatically to assistive technologies.
📸 Before/After: The visual element remains unchanged, but the underlying semantics are improved.
♿ Accessibility: Improves accessibility by mapping visual cues to semantic `aria-keyshortcuts` and hiding redundant visual elements from screen readers.

---
*PR created automatically by Jules for task [2905296339206864039](https://jules.google.com/task/2905296339206864039) started by @igormartins4*