### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -68,6 +68,22 @@ export default defineConfig({
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
     },
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+      'Content-Security-Policy':
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.tile.openstreetmap.org; connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com;",
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+      'Content-Security-Policy':
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.tile.openstreetmap.org; connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com;",
+    },
   },
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(packageJson.version),


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing standard HTTP security headers (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Content-Security-Policy) in the local development and preview environments.
🎯 Impact: While primarily for local environments, missing security headers can mask CSP violations and cross-site vulnerabilities that would otherwise be caught early before deployment, and missing them sets a poor baseline for infrastructure parity.
🔧 Fix: Configured `server` and `preview` blocks in `app/vite.config.ts` to include standard HTTP security headers. The CSP is carefully scoped to allow 'unsafe-inline' and 'unsafe-eval' for Vite's HMR to function, while explicitly allowing connections to Google Analytics and OpenStreetMap to maintain application functionality without triggering spurious console warnings.
✅ Verification: Ran tests (`pnpm test`), lint (`pnpm lint`), and successfully applied the changes.

---
*PR created automatically by Jules for task [16397318432395585900](https://jules.google.com/task/16397318432395585900) started by @igormartins4*