### PR TITLE
🎨 Palette: Improve keyboard shortcut accessibility

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl+', 'Control+') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to visual keyboard shortcut hints (`<kbd>`) and added the `aria-keyshortcuts` attribute to the associated input field, parsing common visual keys into W3C valid modifiers (e.g., '⌘' to 'Meta+').
🎯 Why: Prevents screen readers from making redundant, confusing announcements of the visual hint text while focusing the input, and instead leverages native OS/browser accessibility announcements for keyboard shortcuts.
📸 Before/After: Visual `<kbd>` hint is now hidden from screen readers. Input field now has correctly formatted `aria-keyshortcuts`.
♿ Accessibility: Screen readers will now announce the shortcut directly on the input correctly instead of reading the separate `<kbd>` text as disconnected content.

---
*PR created automatically by Jules for task [9049745788724302123](https://jules.google.com/task/9049745788724302123) started by @igormartins4*