### PR TITLE
🎨 Palette: Add aria-keyshortcuts to SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={shortcut?.replace('⌘', 'Meta+').replace('Ctrl', 'Control')}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +259,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+              aria-hidden="true"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-keyshortcuts` property to the `SearchInput` component and hid the visual `<kbd>` element from screen readers using `aria-hidden="true"`.
🎯 Why: Screen readers would previously announce the visual shortcut text ("Command K") in addition to the input, causing redundancy. By utilizing proper ARIA properties, the shortcut is natively and correctly announced to users relying on assistive technology without visual clutter.
📸 Before/After: Visuals remain unchanged. Screen reader experience improved.
♿ Accessibility: Mapped visual keys `⌘` and `Ctrl` to standard ARIA identifiers `Meta+` and `Control` respectively. Suppressed the decorative `<kbd>` tag to eliminate redundant announcements.

---
*PR created automatically by Jules for task [11683164031079481446](https://jules.google.com/task/11683164031079481446) started by @igormartins4*