### PR TITLE
🛡️ Sentinel: [security improvement] Add HTTP security headers to Vite server

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
- 🚨 Severity: LOW
- 💡 Vulnerability: Missing HTTP security headers (X-Content-Type-Options, X-Frame-Options) on development and preview servers.
- 🎯 Impact: Potential clickjacking and MIME-type sniffing attacks during development.
- 🔧 Fix: Configured Vite's `server.headers` and `preview.headers` to include `nosniff` and `DENY` security headers.
- ✅ Verification: Verify headers are present in local development server and preview server configurations.

---
*PR created automatically by Jules for task [2740368976694607181](https://jules.google.com/task/2740368976694607181) started by @igormartins4*