### PR TITLE
🎨 Palette: [UX improvement] Accessible Keyboard Shortcut Hints

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -218,6 +218,8 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 
     const hasValue = Boolean(value);
 
+    const ariaKeyShortcuts = shortcut?.replace('⌘', 'Meta+').replace('Ctrl+', 'Control+');
+
     return (
       <div data-slot="search-input" className="relative w-full">
         <Search
@@ -232,6 +234,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={ariaKeyShortcuts}
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 **What**:
Improved the accessibility of the `SearchInput` component's keyboard shortcut hint.

🎯 **Why**:
When UI components display visual keyboard shortcut hints (like a `<kbd>⌘K</kbd>` tag), screen readers will often announce them redundantly alongside the input label. Furthermore, without an explicit `aria-keyshortcuts` attribute on the input itself, users relying on assistive technologies might not discover the available shortcut.

📸 **Before/After**:
Visually, the UI remains completely unchanged. The `<kbd>⌘K</kbd>` or `<kbd>Ctrl+K</kbd>` indicator still renders correctly inside the search input. Under the hood, however, screen readers will now ignore the visual hint and announce the standardized ARIA shortcut when the input is focused.

♿ **Accessibility**:
- Translated visual shortcut strings (e.g., `⌘` and `Ctrl+`) into standard ARIA key identifiers (e.g., `Meta+` and `Control+`).
- Added the `aria-keyshortcuts` attribute to the active `<input>` element.
- Added `aria-hidden="true"` to the decorative `<kbd>` element to silence redundant announcements.

---
*PR created automatically by Jules for task [12109069525632941980](https://jules.google.com/task/12109069525632941980) started by @igormartins4*