### PR TITLE
🛡️ Sentinel: [security improvement] Add HTTP security headers to Vite

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,22 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
     },
   },
   define: {


### PR DESCRIPTION
💡 **What**
Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` HTTP security headers to Vite's `server` and `preview` configurations.

🎯 **Why**
To implement defense-in-depth security measures. The `nosniff` header prevents browsers from MIME-sniffing a response away from the declared content-type, reducing the risk of XSS attacks. The `DENY` header for `X-Frame-Options` prevents the application from being embedded in iframes, mitigating clickjacking vulnerabilities.

📊 **Impact**
Enhances the security posture of the local development and preview environments by applying standard HTTP security best practices.

🔬 **Measurement**
Manually verified via `vite preview` network requests or checking the Vite dev server headers to ensure the new security directives are correctly applied. The change passes all tests and linting.

---
*PR created automatically by Jules for task [8687933285105728115](https://jules.google.com/task/8687933285105728115) started by @igormartins4*