### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,28 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+      'Content-Security-Policy':
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.google-analytics.com https://*.analytics.google.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.tile.openstreetmap.org https://*.google-analytics.com https://*.analytics.google.com; connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com; font-src 'self' data:;",
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+      'Content-Security-Policy':
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.google-analytics.com https://*.analytics.google.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.tile.openstreetmap.org https://*.google-analytics.com https://*.analytics.google.com; connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com; font-src 'self' data:;",
     },
   },
   define: {


### PR DESCRIPTION
💡 **What**
Added explicit security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, and `Content-Security-Policy`) to the `server` and `preview` blocks in `app/vite.config.ts`. The CSP is tailored to explicitly allow connections and styles needed for local development (like Vite's HMR WebSockets and `unsafe-inline`) as well as the external APIs the application relies on (`*.tile.openstreetmap.org`, `*.google-analytics.com`, `*.analytics.google.com`).

🎯 **Why**
While Vite's dev server isn't exposed to the public internet, configuring standard security headers in the local development environment represents a "shift-left" security practice. It allows developers to immediately detect and catch Content Security Policy violations locally as they are developing new features, rather than discovering them later when the code is deployed to a staging or production environment where identical headers are enforced.

📊 **Impact**
Developers will now experience local errors if they attempt to load external scripts, styles, or iframes from domains not explicitly allowed in the CSP, mimicking the strictness of a production environment and reducing the likelihood of cross-site scripting (XSS) and data injection vulnerabilities slipping into production.

🔬 **Measurement**
1. Run `pnpm dev` inside the `app` directory.
2. Open the network tab in the browser and inspect the headers for `localhost:5173`.
3. Verify that the response includes `Content-Security-Policy`, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `X-XSS-Protection: 1; mode=block`.
4. Run `pnpm build` and `pnpm preview` to verify identical headers are applied during local production previews.

---
*PR created automatically by Jules for task [9694001568176128186](https://jules.google.com/task/9694001568176128186) started by @igormartins4*