### PR TITLE
🛡️ Sentinel: [security improvement] Add Content Security Policy headers

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -68,6 +68,20 @@ export default defineConfig({
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
     },
+    headers: {
+      'Content-Security-Policy':
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.tile.openstreetmap.org https://*.google-analytics.com https://*.analytics.google.com; connect-src 'self' ws: wss: https://*.tile.openstreetmap.org https://*.google-analytics.com https://*.analytics.google.com;",
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
+  },
+  preview: {
+    headers: {
+      'Content-Security-Policy':
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.tile.openstreetmap.org https://*.google-analytics.com https://*.analytics.google.com; connect-src 'self' ws: wss: https://*.tile.openstreetmap.org https://*.google-analytics.com https://*.analytics.google.com;",
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+    },
   },
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(packageJson.version),


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing Content-Security-Policy and standard HTTP security headers on the development and preview environments.
🎯 Impact: This lack of defense-in-depth increases the risk of Cross-Site Scripting (XSS) and clickjacking attacks. Configuring these headers locally allows developers to catch CSP violations (like calling an unapproved external API) before the code is deployed to production.
🔧 Fix: Added `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, and `X-Frame-Options: DENY` headers to both `server` and `preview` blocks in `vite.config.ts`. The CSP allows only the required third-party resources based on the application's current behavior (e.g. `https://*.tile.openstreetmap.org` and Google Analytics).
✅ Verification: Ran `pnpm test`, `pnpm lint`, `pnpm build`, and verified the configurations in `vite.config.ts`.

---
*PR created automatically by Jules for task [18258597626954710581](https://jules.google.com/task/18258597626954710581) started by @igormartins4*