### PR TITLE
🎨 Palette: Add keyboard accessibility hints to SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,9 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut ? shortcut.replace('⌘', 'Meta+').replace('Ctrl+', 'Control+') : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +261,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What: Added ARIA keyboard shortcut attributes to the SearchInput component.
🎯 Why: Screen readers could redundantly announce the visual `<kbd>⌘K</kbd>` hint, and the actual `<input>` element lacked the semantic `aria-keyshortcuts` attribute to inform assistive technologies of the available shortcut.
📸 Before/After: Visuals remain unchanged (the `<kbd>` is still visible), but the underlying DOM now correctly uses `aria-keyshortcuts="Meta+K"` (or `Control+K`) on the input, and `aria-hidden="true"` on the visual `<kbd>` element.
♿ Accessibility: Improves keyboard shortcut discoverability for screen reader users and reduces auditory clutter by hiding the purely visual hint.

---
*PR created automatically by Jules for task [2309278800243812000](https://jules.google.com/task/2309278800243812000) started by @igormartins4*