### PR TITLE
🎨 Palette: [UX improvement] Add accessible keyboard shortcuts to SearchInput

### DIFF
--- a/app/src/components/ui/Input.tsx
+++ b/app/src/components/ui/Input.tsx
@@ -232,6 +232,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           aria-label={fallbackAriaLabel}
+          aria-keyshortcuts={
+            shortcut
+              ? shortcut.replace(/⌘/g, 'Meta+').replace(/Ctrl/g, 'Control').replace(/\+\+/g, '+')
+              : undefined
+          }
           enterKeyHint="search"
           className={cn(
             inputVariants({
@@ -258,7 +263,11 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           </button>
         ) : shortcut ? (
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 hidden md:block">
-            <kbd className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono">
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: visual shortcut hint only */}
+            <kbd
+              aria-hidden="true"
+              className="inline-flex h-5 items-center rounded border border-card-border bg-background px-1.5 text-[10px] font-medium text-text-tertiary font-mono"
+            >
               {shortcut}
             </kbd>
           </div>


### PR DESCRIPTION
💡 What:
Added standard ARIA accessibility support for keyboard shortcuts in the `SearchInput` component. Converted standard visual Mac/Windows modifier keys (like ⌘ and Ctrl) to standard ARIA formats (Meta+ and Control).

🎯 Why:
Screen readers frequently redundantly announce or misinterpret purely visual keyboard hints (`<kbd>⌘K</kbd>`). By hiding the visual element and properly associating the exact keyboard binding to the active `<input>` via `aria-keyshortcuts`, screen reader users get precise, standard shortcut announcements.

📸 Before/After:
No visual changes.

♿ Accessibility:
* Screen readers no longer redundantly read the `<kbd>` element text when navigating past the input area.
* The input element natively exposes the shortcut binding (e.g. `Meta+K`) directly through the accessibility tree via `aria-keyshortcuts`.

---
*PR created automatically by Jules for task [2211207936139509405](https://jules.google.com/task/2211207936139509405) started by @igormartins4*