### PR TITLE
🎨 Palette: Add aria-label to LineCard button

### DIFF
--- a/app/src/components/LineCard.tsx
+++ b/app/src/components/LineCard.tsx
@@ -268,6 +268,7 @@ function LineCardComponent({
         onClick={handleCardClick}
         aria-pressed={isSelected}
         aria-describedby={getLineDescriptionId(linha.idRota)}
+        aria-label={`Selecionar linha ${linha.nome}`}
         className="w-full cursor-pointer text-left focus-visible:outline-none"
       >
         <div data-slot="header" className="relative w-full p-4 pb-3 text-left">


### PR DESCRIPTION
💡 What
Added an `aria-label` attribute to the main `<button>` wrapper of the `LineCard` component in `app/src/components/LineCard.tsx`.

🎯 Why
The `LineCard` component's primary interactive element is a large button containing multiple disjointed pieces of text (line name, subline name, status, upcoming schedules). When a screen reader focuses on this button, reading all this raw text can be confusing and fails to clearly indicate the button's action. A dedicated `aria-label` provides a concise, actionable summary of what clicking the card does.

📸 Before/After
**Before:**
The `<button>` element only had an `aria-describedby` pointing to a hidden string containing the full text content, but lacked a distinct `aria-label` for the action itself.
```tsx
<button
  type="button"
  data-slot="select-line"
  onClick={handleCardClick}
  aria-pressed={isSelected}
  aria-describedby={getLineDescriptionId(linha.idRota)}
  className="w-full cursor-pointer text-left focus-visible:outline-none"
>
```

**After:**
The `<button>` now includes a clear `aria-label` stating the action ("Selecionar linha [Nome da Linha]").
```tsx
<button
  type="button"
  data-slot="select-line"
  onClick={handleCardClick}
  aria-pressed={isSelected}
  aria-describedby={getLineDescriptionId(linha.idRota)}
  aria-label={`Selecionar linha ${linha.nome}`}
  className="w-full cursor-pointer text-left focus-visible:outline-none"
>
```

♿ Accessibility
Improves the experience for screen reader users by providing a clear, concise announcement of the primary action (e.g., "Selecionar linha Linha 02, botão") when navigating through the list of bus lines, instead of relying on the browser to piece together all the internal text content of the card before indicating it's a button.

---
*PR created automatically by Jules for task [10413414763703019674](https://jules.google.com/task/10413414763703019674) started by @igormartins4*