### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers to Vite config

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -61,12 +61,28 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+      'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+      'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.google-analytics.com https://*.analytics.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.tile.openstreetmap.org https://*.google-analytics.com; connect-src 'self' ws: wss: https://*.tile.openstreetmap.org https://*.google-analytics.com https://*.analytics.google.com;",
+    },
     fs: {
       // Permite que o servidor de desenvolvimento acesse o workspace e o
       // node_modules compartilhado na raiz do monorepo. Sem isso, os arquivos
       // do @fontsource/poppins resolvidos via pnpm ficam fora da allow list
       // e retornam 403 no ambiente local.
       allow: ['..', '../..'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'X-XSS-Protection': '1; mode=block',
+      'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+      'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.google-analytics.com https://*.analytics.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.tile.openstreetmap.org https://*.google-analytics.com; connect-src 'self' ws: wss: https://*.tile.openstreetmap.org https://*.google-analytics.com https://*.analytics.google.com;",
     },
   },
   define: {


### PR DESCRIPTION
🚨 Severity: LOW / ENHANCEMENT
💡 Vulnerability: Missing HTTP security headers (CSP, X-Frame-Options, etc.) on the development and preview servers. While not critical for production if managed externally, missing them locally makes it harder to catch cross-origin, framing, or content-injection issues early.
🎯 Impact: This helps developers catch and fix cross-origin or framing vulnerabilities during development, enforcing defense-in-depth security posture before deploying to production.
🔧 Fix: Added strict security headers, including a tailored `Content-Security-Policy` that permits necessary resources (`openstreetmap`, `google-analytics`, HMR websockets, and inline scripts/styles for development) to the `server` and `preview` blocks in `app/vite.config.ts`.
✅ Verification: Tested development headers implementation using `pnpm lint` and `pnpm test`. Verified configuration changes correctly integrated without breaking existing tests.

---
*PR created automatically by Jules for task [15308972019395963752](https://jules.google.com/task/15308972019395963752) started by @igormartins4*