### PR TITLE
🎨 Palette: Improve tooltip accessibility with keyboard focus and replace native title attrs

### DIFF
--- a/app/src/components/ControlesUsuarioMapa.tsx
+++ b/app/src/components/ControlesUsuarioMapa.tsx
@@ -15,6 +15,7 @@ import { Marker, useMap } from 'react-leaflet';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { COORDENADAS_UFMG } from '../hooks/useLocalizacaoUsuario';
 import { cn } from '../lib/utils';
+import { Tooltip } from './ui/Tooltip';
 
 interface ControlesUsuarioMapaProps {
   /** Coordenadas atuais do usuário [lat, lng] */
@@ -147,58 +148,63 @@ export function ControlesUsuarioMapa({
       {/* FABs - Floating Action Buttons */}
       <div className="fixed bottom-6 right-4 z-1000 flex flex-col gap-2 md:bottom-6">
         {/* Botão: centralizar no campus UFMG */}
-        <button
-          type="button"
-          onClick={handleCentralizarUFMG}
-          className={cn(
-            'flex h-12 w-12 cursor-pointer items-center justify-center',
-            'rounded-full shadow-lg transition-all duration-200',
-            'bg-brand-primary hover:bg-brand-primary/90 active:scale-95',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2',
-          )}
-          aria-label="Centralizar mapa no campus UFMG"
-          title="Centralizar mapa no campus UFMG"
-        >
-          <CornerUpLeft className="h-6 w-6 text-white" aria-hidden="true" />
-        </button>
+        <Tooltip content="Centralizar mapa no campus UFMG" position="left">
+          <button
+            type="button"
+            onClick={handleCentralizarUFMG}
+            className={cn(
+              'flex h-12 w-12 cursor-pointer items-center justify-center',
+              'rounded-full shadow-lg transition-all duration-200',
+              'bg-brand-primary hover:bg-brand-primary/90 active:scale-95',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2',
+            )}
+            aria-label="Centralizar mapa no campus UFMG"
+          >
+            <CornerUpLeft className="h-6 w-6 text-white" aria-hidden="true" />
+          </button>
+        </Tooltip>
 
         {/* Botão: centralizar na localização do usuário */}
-        <button
-          type="button"
-          onClick={handleCentralizar}
-          disabled={carregandoLocalizacao}
-          aria-busy={carregandoLocalizacao}
-          className={cn(
-            // Tamanho mínimo para touch (48x48px) - Mobile friendly
-            'flex h-12 w-12 cursor-pointer items-center justify-center',
-            // Estilo visual - Azul brand igual ao botão Ver Linhas
-            'rounded-full shadow-lg transition-all duration-200',
-            'bg-brand-primary hover:bg-brand-primary/90 active:scale-95',
-            // Focus state para acessibilidade
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2',
-            'disabled:opacity-70 disabled:cursor-not-allowed disabled:active:scale-100',
-          )}
-          aria-label={
+        <Tooltip
+          content={
             carregandoLocalizacao
               ? 'Buscando localização...'
               : permissaoConcedida
                 ? 'Centralizar mapa na minha localização'
                 : 'Ativar localização'
           }
-          title={
-            carregandoLocalizacao
-              ? 'Buscando localização...'
-              : permissaoConcedida
-                ? 'Centralizar mapa na minha localização'
-                : 'Ativar localização'
-          }
+          position="left"
         >
-          {carregandoLocalizacao ? (
-            <LoaderCircle className="h-6 w-6 animate-spin text-white" aria-hidden="true" />
-          ) : (
-            <LocateFixed className="h-6 w-6 text-white" aria-hidden="true" />
-          )}
-        </button>
+          <button
+            type="button"
+            onClick={handleCentralizar}
+            disabled={carregandoLocalizacao}
+            aria-busy={carregandoLocalizacao}
+            className={cn(
+              // Tamanho mínimo para touch (48x48px) - Mobile friendly
+              'flex h-12 w-12 cursor-pointer items-center justify-center',
+              // Estilo visual - Azul brand igual ao botão Ver Linhas
+              'rounded-full shadow-lg transition-all duration-200',
+              'bg-brand-primary hover:bg-brand-primary/90 active:scale-95',
+              // Focus state para acessibilidade
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2',
+              'disabled:opacity-70 disabled:cursor-not-allowed disabled:active:scale-100',
+            )}
+            aria-label={
+              carregandoLocalizacao
+                ? 'Buscando localização...'
+                : permissaoConcedida
+                  ? 'Centralizar mapa na minha localização'
+                  : 'Ativar localização'
+            }
+          >
+            {carregandoLocalizacao ? (
+              <LoaderCircle className="h-6 w-6 animate-spin text-white" aria-hidden="true" />
+            ) : (
+              <LocateFixed className="h-6 w-6 text-white" aria-hidden="true" />
+            )}
+          </button>
+        </Tooltip>
       </div>
     </>
   );

--- a/app/src/components/ThemeToggle.tsx
+++ b/app/src/components/ThemeToggle.tsx
@@ -9,6 +9,7 @@ import { tv, type VariantProps } from 'tailwind-variants';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { cn } from '../lib/utils';
+import { Tooltip } from './ui/Tooltip';
 
 /**
  * Variantes do botão de tema
@@ -76,22 +77,23 @@ export function ThemeToggle({
   };
 
   return (
-    <button
-      type="button"
-      data-slot="toggle"
-      data-state={isDark ? 'dark' : 'light'}
-      onClick={handleToggle}
-      className={cn(themeToggleVariants({ variant, size }), className)}
-      aria-label={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
-      title={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
-      aria-pressed={isDark}
-      {...props}
-    >
-      {isDark ? (
-        <Sun size={iconSize} className="text-brand-accent" aria-hidden="true" />
-      ) : (
-        <Moon size={iconSize} className="text-text-primary" aria-hidden="true" />
-      )}
-    </button>
+    <Tooltip content={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`} position="bottom">
+      <button
+        type="button"
+        data-slot="toggle"
+        data-state={isDark ? 'dark' : 'light'}
+        onClick={handleToggle}
+        className={cn(themeToggleVariants({ variant, size }), className)}
+        aria-label={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
+        aria-pressed={isDark}
+        {...props}
+      >
+        {isDark ? (
+          <Sun size={iconSize} className="text-brand-accent" aria-hidden="true" />
+        ) : (
+          <Moon size={iconSize} className="text-text-primary" aria-hidden="true" />
+        )}
+      </button>
+    </Tooltip>
   );
 }

--- a/app/src/components/ui/Tooltip.tsx
+++ b/app/src/components/ui/Tooltip.tsx
@@ -66,7 +66,13 @@ export function Tooltip({ content, children, className, position = 'top' }: Tool
 
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: wrapper de tooltip — hover-only, sem captura de eventos de clique/toque nos filhos
-    <div className={cn('relative inline-flex', className)} onMouseEnter={show} onMouseLeave={hide}>
+    <div
+      className={cn('relative inline-flex', className)}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
       {children}
       {visible && (
         <div


### PR DESCRIPTION
💡 What: 
- Added `onFocus` and `onBlur` event handlers to the custom `Tooltip` wrapper so it properly displays for keyboard users navigating via Tab, not just mouse hover.
- Replaced the native `title` attribute on the `ThemeToggle` and `ControlesUsuarioMapa` icon-only buttons with the newly enhanced custom `<Tooltip>` wrapper.

🎯 Why: 
Native HTML `title` attributes are problematic for UX and accessibility: they depend on arbitrary OS/browser delays to show, and often do not show up at all for keyboard-only or screen reader users. The custom Tooltip wasn't responding to keyboard focus, leaving keyboard users without critical contextual hints for icon-only action buttons.

📸 Before/After: 
- **Before:** Tabbing to the Theme Toggle or Map FABs provided no visual context; hovering provided the delayed native browser tooltip.
- **After:** Tabbing or hovering over these controls immediately displays a visually consistent and accessible custom tooltip.

♿ Accessibility: 
- Drastically improved keyboard accessibility by ensuring visual context is presented on standard element focus.
- Avoided screen reader redundancies because `aria-label` continues to be preserved on the actual buttons underneath the wrapper.

---
*PR created automatically by Jules for task [5290630017906678060](https://jules.google.com/task/5290630017906678060) started by @igormartins4*