### PR TITLE
🎨 Palette: Add Tooltip for ThemeToggle

### DIFF
--- a/app/src/components/ThemeToggle.tsx
+++ b/app/src/components/ThemeToggle.tsx
@@ -9,6 +9,7 @@ import { tv, type VariantProps } from 'tailwind-variants';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { cn } from '../lib/utils';
+import { Tooltip } from './ui/Tooltip';
 
 /**
  * Variantes do botão de tema
@@ -76,22 +77,23 @@ export function ThemeToggle({
   };
 
   return (
-    <button
-      type="button"
-      data-slot="toggle"
-      data-state={isDark ? 'dark' : 'light'}
-      onClick={handleToggle}
-      className={cn(themeToggleVariants({ variant, size }), className)}
-      aria-label={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
-      title={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
-      aria-pressed={isDark}
-      {...props}
-    >
-      {isDark ? (
-        <Sun size={iconSize} className="text-brand-accent" aria-hidden="true" />
-      ) : (
-        <Moon size={iconSize} className="text-text-primary" aria-hidden="true" />
-      )}
-    </button>
+    <Tooltip content={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}>
+      <button
+        type="button"
+        data-slot="toggle"
+        data-state={isDark ? 'dark' : 'light'}
+        onClick={handleToggle}
+        className={cn(themeToggleVariants({ variant, size }), className)}
+        aria-label={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
+        aria-pressed={isDark}
+        {...props}
+      >
+        {isDark ? (
+          <Sun size={iconSize} className="text-brand-accent" aria-hidden="true" />
+        ) : (
+          <Moon size={iconSize} className="text-text-primary" aria-hidden="true" />
+        )}
+      </button>
+    </Tooltip>
   );
 }

--- a/app/src/components/ui/Tooltip.tsx
+++ b/app/src/components/ui/Tooltip.tsx
@@ -66,7 +66,13 @@ export function Tooltip({ content, children, className, position = 'top' }: Tool
 
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: wrapper de tooltip — hover-only, sem captura de eventos de clique/toque nos filhos
-    <div className={cn('relative inline-flex', className)} onMouseEnter={show} onMouseLeave={hide}>
+    <div
+      className={cn('relative inline-flex', className)}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
       {children}
       {visible && (
         <div


### PR DESCRIPTION
💡 What:
Wrapped the `ThemeToggle` button in the custom `<Tooltip>` component and added `onFocus` and `onBlur` handlers to `<Tooltip>` to support keyboard navigation.

🎯 Why:
The `ThemeToggle` component previously relied on a native HTML `title` attribute. Native tooltips do not show consistently for keyboard users navigating via `Tab` and cannot be styled to match the application's design system. Now, hover and focus states trigger the same styled tooltip component.

📸 Before/After:
Before: Hovering showed a native unstyled tooltip. Tabbing to the button showed nothing.
After: Hovering and focusing both show the stylized custom `<Tooltip>`, maintaining a consistent UX. 

♿ Accessibility:
- Replaced the inaccessible native `title` attribute with a custom semantic tooltip.
- Implemented `onFocus` and `onBlur` events on the generic `<Tooltip>` wrapper `<div>` to ensure screen readers and keyboard-only users receive equivalent contextual feedback.

---
*PR created automatically by Jules for task [8811135575931234739](https://jules.google.com/task/8811135575931234739) started by @igormartins4*