### PR TITLE
🎨 Palette: Replace ThemeToggle native title with accessible Tooltip

### DIFF
--- a/app/src/components/ThemeToggle.tsx
+++ b/app/src/components/ThemeToggle.tsx
@@ -9,6 +9,7 @@ import { tv, type VariantProps } from 'tailwind-variants';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { cn } from '../lib/utils';
+import { Tooltip } from './ui/Tooltip';
 
 /**
  * Variantes do botão de tema
@@ -76,22 +77,23 @@ export function ThemeToggle({
   };
 
   return (
-    <button
-      type="button"
-      data-slot="toggle"
-      data-state={isDark ? 'dark' : 'light'}
-      onClick={handleToggle}
-      className={cn(themeToggleVariants({ variant, size }), className)}
-      aria-label={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
-      title={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
-      aria-pressed={isDark}
-      {...props}
-    >
-      {isDark ? (
-        <Sun size={iconSize} className="text-brand-accent" aria-hidden="true" />
-      ) : (
-        <Moon size={iconSize} className="text-text-primary" aria-hidden="true" />
-      )}
-    </button>
+    <Tooltip content={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}>
+      <button
+        type="button"
+        data-slot="toggle"
+        data-state={isDark ? 'dark' : 'light'}
+        onClick={handleToggle}
+        className={cn(themeToggleVariants({ variant, size }), className)}
+        aria-label={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
+        aria-pressed={isDark}
+        {...props}
+      >
+        {isDark ? (
+          <Sun size={iconSize} className="text-brand-accent" aria-hidden="true" />
+        ) : (
+          <Moon size={iconSize} className="text-text-primary" aria-hidden="true" />
+        )}
+      </button>
+    </Tooltip>
   );
 }

--- a/app/src/components/ui/Tooltip.tsx
+++ b/app/src/components/ui/Tooltip.tsx
@@ -66,7 +66,13 @@ export function Tooltip({ content, children, className, position = 'top' }: Tool
 
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: wrapper de tooltip — hover-only, sem captura de eventos de clique/toque nos filhos
-    <div className={cn('relative inline-flex', className)} onMouseEnter={show} onMouseLeave={hide}>
+    <div
+      className={cn('relative inline-flex', className)}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
       {children}
       {visible && (
         <div


### PR DESCRIPTION
💡 What: Replaced the native HTML `title` attribute on the `ThemeToggle` button with the design system's `<Tooltip>` component. Additionally, enhanced the `Tooltip` component itself to support `onFocus` and `onBlur` events.

🎯 Why: The native `title` attribute is notoriously inaccessible for keyboard-only users and inconsistent across browsers. By leveraging the `<Tooltip>` component and ensuring it reacts to focus events, we provide a consistent, accessible experience for all users when discovering the theme toggle functionality.

📸 Before/After: Visual changes are evident in the tooltip presentation (now using the dark baloon with CSS arrow instead of browser default), but more crucially, the tooltip is now triggerable via keyboard focus.

♿ Accessibility: Significantly improved keyboard accessibility by allowing the theme toggle's explanatory tooltip to appear when navigating via `Tab`, ensuring equivalent contextual feedback for screen readers and keyboard-only users.

---
*PR created automatically by Jules for task [5617033817798880034](https://jules.google.com/task/5617033817798880034) started by @igormartins4*