### PR TITLE
🎨 Palette: Enhance ThemeToggle accessibility by replacing native title with Tooltip

### DIFF
--- a/app/src/components/ThemeToggle.tsx
+++ b/app/src/components/ThemeToggle.tsx
@@ -9,6 +9,7 @@ import { tv, type VariantProps } from 'tailwind-variants';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { cn } from '../lib/utils';
+import { Tooltip } from './ui/Tooltip';
 
 /**
  * Variantes do botão de tema
@@ -76,22 +77,23 @@ export function ThemeToggle({
   };
 
   return (
-    <button
-      type="button"
-      data-slot="toggle"
-      data-state={isDark ? 'dark' : 'light'}
-      onClick={handleToggle}
-      className={cn(themeToggleVariants({ variant, size }), className)}
-      aria-label={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
-      title={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
-      aria-pressed={isDark}
-      {...props}
-    >
-      {isDark ? (
-        <Sun size={iconSize} className="text-brand-accent" aria-hidden="true" />
-      ) : (
-        <Moon size={iconSize} className="text-text-primary" aria-hidden="true" />
-      )}
-    </button>
+    <Tooltip content={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`} position="bottom">
+      <button
+        type="button"
+        data-slot="toggle"
+        data-state={isDark ? 'dark' : 'light'}
+        onClick={handleToggle}
+        className={cn(themeToggleVariants({ variant, size }), className)}
+        aria-label={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
+        aria-pressed={isDark}
+        {...props}
+      >
+        {isDark ? (
+          <Sun size={iconSize} className="text-brand-accent" aria-hidden="true" />
+        ) : (
+          <Moon size={iconSize} className="text-text-primary" aria-hidden="true" />
+        )}
+      </button>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
💡 What: Replaced the native HTML `title` attribute on the `ThemeToggle` component with the design system's custom `<Tooltip>` component.

🎯 Why: The native HTML `title` attribute lacks robust accessibility support, particularly for keyboard-only users who tab to the element, and it is frequently ignored or poorly presented by screen readers. By using the custom Tooltip component, we provide consistent, guaranteed contextual hints.

📸 Before/After: Before, relying on browser-default title attributes which behave inconsistently across platforms and don't trigger on keyboard focus. After, consistent visual and accessible tooltip rendering.

♿ Accessibility: The custom `<Tooltip>` natively handles `onFocus` and `onBlur` via React event bubbling, meaning keyboard-only users will now see the hint "Alternar tema" just as mouse users do when interacting with the theme toggle button.

---
*PR created automatically by Jules for task [2098048932038424575](https://jules.google.com/task/2098048932038424575) started by @igormartins4*