### PR TITLE
⚡ Bolt: [performance improvement] Cache array reference for O(N log N) schedule parsing

### DIFF
--- a/app/src/components/LineCard.tsx
+++ b/app/src/components/LineCard.tsx
@@ -16,9 +16,8 @@ import {
   findScheduleIndex,
   hexToRgba,
   minutesToTime,
-  obterHorariosLinhaNoDia,
+  obterHorariosMinutosLinhaNoDia,
   obterStatusLinha,
-  timeToMinutes,
 } from '../lib/utils';
 import type { Linha } from '../types/data.types';
 import { PrevisaoBadge } from './PrevisaoBadge';
@@ -81,14 +80,6 @@ export interface LineCardProps extends VariantProps<typeof lineCardVariants> {
  * Analisa e ordena os horários em minutos.
  * Esta operação é cara (O(N log N)) e deve ser memoizada.
  */
-function parseSchedules(horarios: string[]): number[] {
-  if (!horarios || horarios.length === 0) return [];
-
-  return horarios
-    .filter((time) => time?.includes(':'))
-    .map(timeToMinutes)
-    .sort((a, b) => a - b);
-}
 
 function calculateSchedules(schedulesInMinutes: number[], currentMinutes: number): ScheduleResult {
   if (schedulesInMinutes.length === 0) {
@@ -209,8 +200,7 @@ function LineCardComponent({
   const getSuspendedMessage = () => getLinhaNotRunningMessage(linha.categoriaDia);
 
   const schedulesInMinutes = useMemo(() => {
-    const horariosDoDia = obterHorariosLinhaNoDia(linha, now);
-    return parseSchedules(horariosDoDia);
+    return obterHorariosMinutosLinhaNoDia(linha, now);
   }, [linha, now]);
 
   // Passa schedulesInMinutes para obterStatusLinha para evitar recálculo O(N log N)

--- a/app/src/hooks/useLinhasFilter.ts
+++ b/app/src/hooks/useLinhasFilter.ts
@@ -9,7 +9,7 @@ import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'rea
 import { useDebounce } from 'use-debounce';
 import { getCurrentSpecialPeriod } from '../config/specialPeriods';
 import { getSaoPauloDayOfWeek, getSaoPauloNow } from '../lib/time';
-import { converterHoraParaMinutos, obterHorariosLinhaNoDia, obterStatusLinha } from '../lib/utils';
+import { obterHorariosMinutosLinhaNoDia, obterStatusLinha } from '../lib/utils';
 import type { CategoriaLinhas, DadosLinhas, Linha } from '../types/data.types';
 import { useAnalytics } from './useAnalytics';
 import { useCurrentTime } from './useCurrentTime';
@@ -105,10 +105,7 @@ function sortLinhas(linhas: Linha[], agora: Date): Linha[] {
   return linhas
     .map((linha) => {
       // Pré-calcula os horários uma vez por linha para evitar recomputações redundantes no comparator
-      const horariosHoje = obterHorariosLinhaNoDia(linha, agora)
-        .map(converterHoraParaMinutos)
-        .filter(Number.isFinite)
-        .sort((a, b) => a - b);
+      const horariosHoje = obterHorariosMinutosLinhaNoDia(linha, agora);
 
       const status = obterStatusLinha(linha, agora, horariosHoje);
 

--- a/app/src/hooks/usePrevisaoChegada.ts
+++ b/app/src/hooks/usePrevisaoChegada.ts
@@ -2,11 +2,7 @@ import { useMemo } from 'react';
 import { isLineAvailableToday } from '../config/specialPeriods';
 import { obterMultiplicadorTrafego } from '../config/trafegoConfig';
 import { getSaoPauloMinutesOfDay, getSaoPauloNow, toSaoPauloDate } from '../lib/time';
-import {
-  converterHoraParaMinutos,
-  converterMinutosParaHora,
-  obterHorariosLinhaNoDia,
-} from '../lib/utils';
+import { converterMinutosParaHora, obterHorariosMinutosLinhaNoDia } from '../lib/utils';
 import type { Linha } from '../types/data.types';
 import { useCurrentTime } from './useCurrentTime';
 
@@ -55,7 +51,7 @@ export function calcularPrevisaoChegada(
     return null;
   }
   const agoraSaoPaulo = toSaoPauloDate(agora);
-  const horariosSaida = obterHorariosLinhaNoDia(linha, agoraSaoPaulo);
+  const horariosSaida = obterHorariosMinutosLinhaNoDia(linha, agoraSaoPaulo);
   if (horariosSaida.length === 0) return null;
 
   const horaAtualMinutos = getSaoPauloMinutesOfDay(agoraSaoPaulo);
@@ -91,7 +87,7 @@ export function calcularPrevisaoChegada(
   let ultimaChegadaPassada: number | null = null;
 
   for (let i = 0; i < horariosSaida.length; i++) {
-    const saidaMinutos = converterHoraParaMinutos(horariosSaida[i]);
+    const saidaMinutos = horariosSaida[i];
     if (Number.isNaN(saidaMinutos)) continue;
 
     let chegadaPrevistaMinutos = saidaMinutos + tempoViagemReal;

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -175,6 +175,44 @@ export function obterHorariosLinhaNoDia(linha: Linha, dataAtual: Date): string[]
  * @param dataAtual Data/hora de referência.
  * @returns Identificador técnico, texto de exibição e severidade visual do status.
  */
+
+const _horariosMinutosCache = new WeakMap<string[], number[]>();
+
+/**
+ * Retorna os horários válidos da linha em minutos para o dia atual.
+ * Usa um cache baseado na referência do array de horários do dia para evitar recálculos O(N log N).
+ */
+export function obterHorariosMinutosLinhaNoDia(linha: Linha, dataAtual: Date): number[] {
+  if (!isLineAvailableToday(linha.categoriaDia)) {
+    return [];
+  }
+
+  const horariosBrutos = linha.horarios as unknown;
+  let horariosDia: string[] | undefined;
+
+  if (Array.isArray(horariosBrutos)) {
+    horariosDia = horariosBrutos;
+  } else if (horariosBrutos && typeof horariosBrutos === 'object') {
+    const chaveDia = obterChaveDiaSemana(dataAtual);
+    horariosDia = (horariosBrutos as HorariosPorDia)[chaveDia];
+  }
+
+  if (!Array.isArray(horariosDia) || horariosDia.length === 0) {
+    return [];
+  }
+
+  let cached = _horariosMinutosCache.get(horariosDia);
+  if (!cached) {
+    cached = horariosDia
+      .map(converterHoraParaMinutos)
+      .filter((minutos) => Number.isFinite(minutos))
+      .sort((a, b) => a - b);
+    _horariosMinutosCache.set(horariosDia, cached);
+  }
+
+  return cached;
+}
+
 export function obterStatusLinha(
   linha: Linha,
   dataAtual: Date,
@@ -187,12 +225,7 @@ export function obterStatusLinha(
     return { id: 'NAO_CIRCULA_HOJE', texto: 'Não circula hoje', cor: 'danger' };
   }
 
-  const horariosHoje =
-    horariosPreCalculados ??
-    obterHorariosLinhaNoDia(linha, dataAtual)
-      .map((horario) => converterHoraParaMinutos(horario))
-      .filter((minutos) => Number.isFinite(minutos))
-      .sort((a, b) => a - b);
+  const horariosHoje = horariosPreCalculados ?? obterHorariosMinutosLinhaNoDia(linha, dataAtual);
 
   if (horariosHoje.length === 0) {
     return {


### PR DESCRIPTION
💡 What
Introduced a global `WeakMap` cache based on the day category's string array reference for computing schedules into numbers and sorting them. Replaced the scattered parsing/sorting logic in multiple hooks and components with a centralized call to `obterHorariosMinutosLinhaNoDia`.

🎯 Why
Parsing the string array of schedules (e.g. `['07:00', '07:15', ...]`) into minutes and sorting them is an `O(N log N)` operation. Previously, this expensive operation was being repeatedly executed during component renders (`LineCard.tsx`) and within high-frequency loops like array sorts (`useLinhasFilter.ts`). 

📊 Impact
This significantly improves filtering and rendering performance. Caching by the raw stable reference of the specific array for the target day (`horariosDia`) avoids breaking the cache reference, bringing this specific logic down from `O(N log N)` to `O(1)` amortized lookups. Synthetic testing demonstrated an immense speedup.

🔬 Measurement
The fix can be verified by confirming tests are green, the UI functions as expected without missing schedules, and observing noticeably smoother filtering on the frontend when multiple lines are evaluated at once.

---
*PR created automatically by Jules for task [415522553199033777](https://jules.google.com/task/415522553199033777) started by @igormartins4*