### PR TITLE
🎨 Palette: Improve micro-UX of ThemeToggle with custom Tooltip

### DIFF
--- a/app/src/components/ThemeToggle.tsx
+++ b/app/src/components/ThemeToggle.tsx
@@ -9,6 +9,7 @@ import { tv, type VariantProps } from 'tailwind-variants';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { cn } from '../lib/utils';
+import { Tooltip } from './ui/Tooltip';
 
 /**
  * Variantes do botão de tema
@@ -75,23 +76,26 @@ export function ThemeToggle({
     toggleTheme();
   };
 
+  const tooltipText = `Alternar para tema ${isDark ? 'claro' : 'escuro'}`;
+
   return (
-    <button
-      type="button"
-      data-slot="toggle"
-      data-state={isDark ? 'dark' : 'light'}
-      onClick={handleToggle}
-      className={cn(themeToggleVariants({ variant, size }), className)}
-      aria-label={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
-      title={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
-      aria-pressed={isDark}
-      {...props}
-    >
-      {isDark ? (
-        <Sun size={iconSize} className="text-brand-accent" aria-hidden="true" />
-      ) : (
-        <Moon size={iconSize} className="text-text-primary" aria-hidden="true" />
-      )}
-    </button>
+    <Tooltip content={tooltipText} position="bottom">
+      <button
+        type="button"
+        data-slot="toggle"
+        data-state={isDark ? 'dark' : 'light'}
+        onClick={handleToggle}
+        className={cn(themeToggleVariants({ variant, size }), className)}
+        aria-label={tooltipText}
+        aria-pressed={isDark}
+        {...props}
+      >
+        {isDark ? (
+          <Sun size={iconSize} className="text-brand-accent" aria-hidden="true" />
+        ) : (
+          <Moon size={iconSize} className="text-text-primary" aria-hidden="true" />
+        )}
+      </button>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
💡 What:
Replaced the native browser `title` attribute with the internal design system's `<Tooltip>` component on the `ThemeToggle` icon-only button.

🎯 Why:
Native `title` attributes have inconsistent styling across browsers, often delay appearing, and provide a subpar experience. Using the custom tooltip immediately improves the visual polish and provides a cleaner micro-UX for users trying to understand the icon's purpose.

📸 Before/After:
Before: The browser's default tooltip would appear after hovering, with unstyled OS-level rendering.
After: A styled, immediate, dark-themed tooltip appears predictably on hover or focus, matching the rest of the application's design language.

♿ Accessibility:
The custom `<Tooltip>` component natively handles `onFocus` and `onBlur` via React event bubbling, ensuring keyboard users receive the exact same contextual feedback as mouse users without needing the native `title` fallback. The root interactive element maintains its `aria-label` for screen readers.

---
*PR created automatically by Jules for task [4086755006841882449](https://jules.google.com/task/4086755006841882449) started by @igormartins4*