### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to admin paradas close button

### DIFF
--- a/app/src/components/admin/AdminParadasTab.tsx
+++ b/app/src/components/admin/AdminParadasTab.tsx
@@ -221,6 +221,7 @@ export function AdminParadasTab({
                   setShowDeleteConfirm(false);
                 }}
                 className="text-text-secondary hover:text-text-primary text-lg leading-none"
+                aria-label="Fechar"
               >
                 ×
               </button>


### PR DESCRIPTION
💡 What: Added an `aria-label="Fechar"` attribute to the icon-only "×" close button in the editing panel of the `AdminParadasTab` component.

🎯 Why: The button previously relied solely on the visual "×" character to indicate its function, which provides no context to screen reader users, making the action inaccessible to them.

📸 Before/After: Visual appearance is identical. The underlying HTML now includes the accessibility attribute.

♿ Accessibility: Ensures that screen reader users can understand the purpose of the button (to close the editing panel) without relying on visual cues.

---
*PR created automatically by Jules for task [15265711884866468957](https://jules.google.com/task/15265711884866468957) started by @igormartins4*