### PR TITLE
🎨 Palette: [UX improvement] Replace Theme Toggle native title with Tooltip

### DIFF
--- a/app/src/components/ThemeToggle.tsx
+++ b/app/src/components/ThemeToggle.tsx
@@ -9,6 +9,7 @@ import { tv, type VariantProps } from 'tailwind-variants';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { cn } from '../lib/utils';
+import { Tooltip } from './ui/Tooltip';
 
 /**
  * Variantes do botão de tema
@@ -76,22 +77,23 @@ export function ThemeToggle({
   };
 
   return (
-    <button
-      type="button"
-      data-slot="toggle"
-      data-state={isDark ? 'dark' : 'light'}
-      onClick={handleToggle}
-      className={cn(themeToggleVariants({ variant, size }), className)}
-      aria-label={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
-      title={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
-      aria-pressed={isDark}
-      {...props}
-    >
-      {isDark ? (
-        <Sun size={iconSize} className="text-brand-accent" aria-hidden="true" />
-      ) : (
-        <Moon size={iconSize} className="text-text-primary" aria-hidden="true" />
-      )}
-    </button>
+    <Tooltip content={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`} position="bottom">
+      <button
+        type="button"
+        data-slot="toggle"
+        data-state={isDark ? 'dark' : 'light'}
+        onClick={handleToggle}
+        className={cn(themeToggleVariants({ variant, size }), className)}
+        aria-label={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
+        aria-pressed={isDark}
+        {...props}
+      >
+        {isDark ? (
+          <Sun size={iconSize} className="text-brand-accent" aria-hidden="true" />
+        ) : (
+          <Moon size={iconSize} className="text-text-primary" aria-hidden="true" />
+        )}
+      </button>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
💡 What: Replaced the native HTML `title` attribute on the ThemeToggle button with the project's custom `<Tooltip>` component.
🎯 Why: Native `title` tooltips lack robust styling, predictable timing, and consistent keyboard accessibility support, making them a poor experience. The custom Tooltip handles focus/blur seamlessly via React event bubbling, providing a much better native UX and a11y for assistive technology.
📸 Before/After: Before, a system-default hover tip appeared only for mouse users. Now, the styled Tooltip appears smoothly and consistently. Visuals verified via Playwright.
♿ Accessibility: Improves accessibility by using a dedicated component that explicitly handles focus visibility and ARIA compliance over the problematic native title attribute.

---
*PR created automatically by Jules for task [17576251954094302919](https://jules.google.com/task/17576251954094302919) started by @igormartins4*