### PR TITLE
🎨 Palette: [UX improvement] Replace native tooltips with accessible custom tooltips on map controls and theme toggle

### DIFF
--- a/app/src/components/ControlesUsuarioMapa.tsx
+++ b/app/src/components/ControlesUsuarioMapa.tsx
@@ -15,6 +15,7 @@ import { Marker, useMap } from 'react-leaflet';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { COORDENADAS_UFMG } from '../hooks/useLocalizacaoUsuario';
 import { cn } from '../lib/utils';
+import { Tooltip } from './ui/Tooltip';
 
 interface ControlesUsuarioMapaProps {
   /** Coordenadas atuais do usuário [lat, lng] */
@@ -147,58 +148,63 @@ export function ControlesUsuarioMapa({
       {/* FABs - Floating Action Buttons */}
       <div className="fixed bottom-6 right-4 z-1000 flex flex-col gap-2 md:bottom-6">
         {/* Botão: centralizar no campus UFMG */}
-        <button
-          type="button"
-          onClick={handleCentralizarUFMG}
-          className={cn(
-            'flex h-12 w-12 cursor-pointer items-center justify-center',
-            'rounded-full shadow-lg transition-all duration-200',
-            'bg-brand-primary hover:bg-brand-primary/90 active:scale-95',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2',
-          )}
-          aria-label="Centralizar mapa no campus UFMG"
-          title="Centralizar mapa no campus UFMG"
-        >
-          <CornerUpLeft className="h-6 w-6 text-white" aria-hidden="true" />
-        </button>
+        <Tooltip content="Centralizar mapa no campus UFMG" position="left">
+          <button
+            type="button"
+            onClick={handleCentralizarUFMG}
+            className={cn(
+              'flex h-12 w-12 cursor-pointer items-center justify-center',
+              'rounded-full shadow-lg transition-all duration-200',
+              'bg-brand-primary hover:bg-brand-primary/90 active:scale-95',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2',
+            )}
+            aria-label="Centralizar mapa no campus UFMG"
+          >
+            <CornerUpLeft className="h-6 w-6 text-white" aria-hidden="true" />
+          </button>
+        </Tooltip>
 
         {/* Botão: centralizar na localização do usuário */}
-        <button
-          type="button"
-          onClick={handleCentralizar}
-          disabled={carregandoLocalizacao}
-          aria-busy={carregandoLocalizacao}
-          className={cn(
-            // Tamanho mínimo para touch (48x48px) - Mobile friendly
-            'flex h-12 w-12 cursor-pointer items-center justify-center',
-            // Estilo visual - Azul brand igual ao botão Ver Linhas
-            'rounded-full shadow-lg transition-all duration-200',
-            'bg-brand-primary hover:bg-brand-primary/90 active:scale-95',
-            // Focus state para acessibilidade
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2',
-            'disabled:opacity-70 disabled:cursor-not-allowed disabled:active:scale-100',
-          )}
-          aria-label={
+        <Tooltip
+          content={
             carregandoLocalizacao
               ? 'Buscando localização...'
               : permissaoConcedida
                 ? 'Centralizar mapa na minha localização'
                 : 'Ativar localização'
           }
-          title={
-            carregandoLocalizacao
-              ? 'Buscando localização...'
-              : permissaoConcedida
-                ? 'Centralizar mapa na minha localização'
-                : 'Ativar localização'
-          }
+          position="left"
         >
-          {carregandoLocalizacao ? (
-            <LoaderCircle className="h-6 w-6 animate-spin text-white" aria-hidden="true" />
-          ) : (
-            <LocateFixed className="h-6 w-6 text-white" aria-hidden="true" />
-          )}
-        </button>
+          <button
+            type="button"
+            onClick={handleCentralizar}
+            disabled={carregandoLocalizacao}
+            aria-busy={carregandoLocalizacao}
+            className={cn(
+              // Tamanho mínimo para touch (48x48px) - Mobile friendly
+              'flex h-12 w-12 cursor-pointer items-center justify-center',
+              // Estilo visual - Azul brand igual ao botão Ver Linhas
+              'rounded-full shadow-lg transition-all duration-200',
+              'bg-brand-primary hover:bg-brand-primary/90 active:scale-95',
+              // Focus state para acessibilidade
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2',
+              'disabled:opacity-70 disabled:cursor-not-allowed disabled:active:scale-100',
+            )}
+            aria-label={
+              carregandoLocalizacao
+                ? 'Buscando localização...'
+                : permissaoConcedida
+                  ? 'Centralizar mapa na minha localização'
+                  : 'Ativar localização'
+            }
+          >
+            {carregandoLocalizacao ? (
+              <LoaderCircle className="h-6 w-6 animate-spin text-white" aria-hidden="true" />
+            ) : (
+              <LocateFixed className="h-6 w-6 text-white" aria-hidden="true" />
+            )}
+          </button>
+        </Tooltip>
       </div>
     </>
   );

--- a/app/src/components/ThemeToggle.tsx
+++ b/app/src/components/ThemeToggle.tsx
@@ -9,6 +9,7 @@ import { tv, type VariantProps } from 'tailwind-variants';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { cn } from '../lib/utils';
+import { Tooltip } from './ui/Tooltip';
 
 /**
  * Variantes do botão de tema
@@ -76,22 +77,23 @@ export function ThemeToggle({
   };
 
   return (
-    <button
-      type="button"
-      data-slot="toggle"
-      data-state={isDark ? 'dark' : 'light'}
-      onClick={handleToggle}
-      className={cn(themeToggleVariants({ variant, size }), className)}
-      aria-label={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
-      title={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
-      aria-pressed={isDark}
-      {...props}
-    >
-      {isDark ? (
-        <Sun size={iconSize} className="text-brand-accent" aria-hidden="true" />
-      ) : (
-        <Moon size={iconSize} className="text-text-primary" aria-hidden="true" />
-      )}
-    </button>
+    <Tooltip content={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`} position="bottom">
+      <button
+        type="button"
+        data-slot="toggle"
+        data-state={isDark ? 'dark' : 'light'}
+        onClick={handleToggle}
+        className={cn(themeToggleVariants({ variant, size }), className)}
+        aria-label={`Alternar para tema ${isDark ? 'claro' : 'escuro'}`}
+        aria-pressed={isDark}
+        {...props}
+      >
+        {isDark ? (
+          <Sun size={iconSize} className="text-brand-accent" aria-hidden="true" />
+        ) : (
+          <Moon size={iconSize} className="text-text-primary" aria-hidden="true" />
+        )}
+      </button>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
### 💡 What
Replaced native HTML `title` attributes with the custom `<Tooltip>` component on the map control FABs (`ControlesUsuarioMapa.tsx`) and the Theme Toggle button (`ThemeToggle.tsx`). 

### 🎯 Why
Native HTML `title` attributes are notoriously slow to appear, inconsistently styled across browsers, and often poorly supported by screen readers or keyboard navigation. Replacing them with the app's custom `<Tooltip>` component provides immediate, beautifully styled contextual feedback on both hover and keyboard focus, making the micro-interactions feel much smoother and cohesive with the rest of the application's design system.

### 📸 Before/After
**Before:** Map controls and theme toggle relied on unstyled OS-level `title` tooltips that took a second to appear.
**After:** Instant, styled dark-mode tooltips appear on hover and focus.

### ♿ Accessibility
- Retained the `aria-label` on the underlying `button` elements to ensure screen readers announce the action correctly without double-announcing (since `title` was removed).
- The custom `<Tooltip>` component intrinsically handles keyboard `focus` and `blur` events, ensuring keyboard-only users receive the same visual contextual hints as mouse users, which native `title` attributes often fail to do reliably.

---
*PR created automatically by Jules for task [17382719775513188322](https://jules.google.com/task/17382719775513188322) started by @igormartins4*