### PR TITLE
⚡ Bolt: Optimize schedule parsing using WeakMap cache

### DIFF
--- a/app/src/components/LineCard.tsx
+++ b/app/src/components/LineCard.tsx
@@ -16,9 +16,8 @@ import {
   findScheduleIndex,
   hexToRgba,
   minutesToTime,
-  obterHorariosLinhaNoDia,
+  obterHorariosMinutosLinhaNoDia,
   obterStatusLinha,
-  timeToMinutes,
 } from '../lib/utils';
 import type { Linha } from '../types/data.types';
 import { PrevisaoBadge } from './PrevisaoBadge';
@@ -75,19 +74,6 @@ export interface LineCardProps extends VariantProps<typeof lineCardVariants> {
   idParada?: string;
   /** Classe CSS adicional */
   className?: string;
-}
-
-/**
- * Analisa e ordena os horários em minutos.
- * Esta operação é cara (O(N log N)) e deve ser memoizada.
- */
-function parseSchedules(horarios: string[]): number[] {
-  if (!horarios || horarios.length === 0) return [];
-
-  return horarios
-    .filter((time) => time?.includes(':'))
-    .map(timeToMinutes)
-    .sort((a, b) => a - b);
 }
 
 function calculateSchedules(schedulesInMinutes: number[], currentMinutes: number): ScheduleResult {
@@ -209,8 +195,7 @@ function LineCardComponent({
   const getSuspendedMessage = () => getLinhaNotRunningMessage(linha.categoriaDia);
 
   const schedulesInMinutes = useMemo(() => {
-    const horariosDoDia = obterHorariosLinhaNoDia(linha, now);
-    return parseSchedules(horariosDoDia);
+    return obterHorariosMinutosLinhaNoDia(linha, now);
   }, [linha, now]);
 
   // Passa schedulesInMinutes para obterStatusLinha para evitar recálculo O(N log N)

--- a/app/src/hooks/useLinhasFilter.ts
+++ b/app/src/hooks/useLinhasFilter.ts
@@ -9,7 +9,7 @@ import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'rea
 import { useDebounce } from 'use-debounce';
 import { getCurrentSpecialPeriod } from '../config/specialPeriods';
 import { getSaoPauloDayOfWeek, getSaoPauloNow } from '../lib/time';
-import { converterHoraParaMinutos, obterHorariosLinhaNoDia, obterStatusLinha } from '../lib/utils';
+import { obterHorariosMinutosLinhaNoDia, obterStatusLinha } from '../lib/utils';
 import type { CategoriaLinhas, DadosLinhas, Linha } from '../types/data.types';
 import { useAnalytics } from './useAnalytics';
 import { useCurrentTime } from './useCurrentTime';
@@ -105,10 +105,7 @@ function sortLinhas(linhas: Linha[], agora: Date): Linha[] {
   return linhas
     .map((linha) => {
       // Pré-calcula os horários uma vez por linha para evitar recomputações redundantes no comparator
-      const horariosHoje = obterHorariosLinhaNoDia(linha, agora)
-        .map(converterHoraParaMinutos)
-        .filter(Number.isFinite)
-        .sort((a, b) => a - b);
+      const horariosHoje = obterHorariosMinutosLinhaNoDia(linha, agora);
 
       const status = obterStatusLinha(linha, agora, horariosHoje);
 

--- a/app/src/hooks/usePrevisaoChegada.ts
+++ b/app/src/hooks/usePrevisaoChegada.ts
@@ -2,11 +2,7 @@ import { useMemo } from 'react';
 import { isLineAvailableToday } from '../config/specialPeriods';
 import { obterMultiplicadorTrafego } from '../config/trafegoConfig';
 import { getSaoPauloMinutesOfDay, getSaoPauloNow, toSaoPauloDate } from '../lib/time';
-import {
-  converterHoraParaMinutos,
-  converterMinutosParaHora,
-  obterHorariosLinhaNoDia,
-} from '../lib/utils';
+import { converterMinutosParaHora, obterHorariosMinutosLinhaNoDia } from '../lib/utils';
 import type { Linha } from '../types/data.types';
 import { useCurrentTime } from './useCurrentTime';
 
@@ -55,8 +51,8 @@ export function calcularPrevisaoChegada(
     return null;
   }
   const agoraSaoPaulo = toSaoPauloDate(agora);
-  const horariosSaida = obterHorariosLinhaNoDia(linha, agoraSaoPaulo);
-  if (horariosSaida.length === 0) return null;
+  const horariosSaidaMinutos = obterHorariosMinutosLinhaNoDia(linha, agoraSaoPaulo);
+  if (horariosSaidaMinutos.length === 0) return null;
 
   const horaAtualMinutos = getSaoPauloMinutesOfDay(agoraSaoPaulo);
   const multiplicadorTrafego = obterMultiplicadorTrafego(horaAtualMinutos);
@@ -90,9 +86,8 @@ export function calcularPrevisaoChegada(
   let proximoOnibus: ProximoOnibus | null = null;
   let ultimaChegadaPassada: number | null = null;
 
-  for (let i = 0; i < horariosSaida.length; i++) {
-    const saidaMinutos = converterHoraParaMinutos(horariosSaida[i]);
-    if (Number.isNaN(saidaMinutos)) continue;
+  for (let i = 0; i < horariosSaidaMinutos.length; i++) {
+    const saidaMinutos = horariosSaidaMinutos[i];
 
     let chegadaPrevistaMinutos = saidaMinutos + tempoViagemReal;
 

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -141,6 +141,48 @@ function obterChaveDiaSemana(dataAtual: Date): keyof HorariosPorDia {
  * @param dataAtual Data usada para escolher o conjunto de horários vigente.
  * @returns Lista de horários válidos para o dia, já filtrada por formato.
  */
+
+const _horariosMinutosCache = new WeakMap<string[], number[]>();
+
+/**
+ * Retorna os horários da linha convertidos em minutos e ordenados,
+ * utilizando um cache (WeakMap) baseado na referência original do array do dia
+ * para evitar recomputações repetidas e economizar processamento (O(N log N)).
+ */
+export function obterHorariosMinutosLinhaNoDia(linha: Linha, dataAtual: Date): number[] {
+  if (!isLineAvailableToday(linha.categoriaDia)) {
+    return [];
+  }
+
+  const horariosBrutos = linha.horarios as unknown;
+  let arrayOriginal: string[] | undefined;
+
+  if (Array.isArray(horariosBrutos)) {
+    arrayOriginal = horariosBrutos;
+  } else if (horariosBrutos && typeof horariosBrutos === 'object') {
+    const chaveDia = obterChaveDiaSemana(dataAtual);
+    arrayOriginal = (horariosBrutos as HorariosPorDia)[chaveDia];
+  }
+
+  if (!Array.isArray(arrayOriginal) || arrayOriginal.length === 0) {
+    return [];
+  }
+
+  let cached = _horariosMinutosCache.get(arrayOriginal);
+  if (!cached) {
+    cached = arrayOriginal
+      .map((h) => {
+        if (typeof h !== 'string' || !h.includes(':')) return NaN;
+        return converterHoraParaMinutos(h);
+      })
+      .filter((m) => Number.isFinite(m))
+      .sort((a, b) => a - b);
+    _horariosMinutosCache.set(arrayOriginal, cached);
+  }
+
+  return cached;
+}
+
 export function obterHorariosLinhaNoDia(linha: Linha, dataAtual: Date): string[] {
   // Regra de negócio central: somente linhas vigentes no dia entram no motor de horários/ETA.
   if (!isLineAvailableToday(linha.categoriaDia)) {
@@ -187,12 +229,7 @@ export function obterStatusLinha(
     return { id: 'NAO_CIRCULA_HOJE', texto: 'Não circula hoje', cor: 'danger' };
   }
 
-  const horariosHoje =
-    horariosPreCalculados ??
-    obterHorariosLinhaNoDia(linha, dataAtual)
-      .map((horario) => converterHoraParaMinutos(horario))
-      .filter((minutos) => Number.isFinite(minutos))
-      .sort((a, b) => a - b);
+  const horariosHoje = horariosPreCalculados ?? obterHorariosMinutosLinhaNoDia(linha, dataAtual);
 
   if (horariosHoje.length === 0) {
     return {


### PR DESCRIPTION
💡 What: Introduced a `WeakMap`-based caching mechanism (`obterHorariosMinutosLinhaNoDia`) to memoize the string-to-minutes conversion and sorting of bus schedules. Replaced `O(N log N)` recomputations in `useLinhasFilter`, `usePrevisaoChegada`, and `LineCard` with `O(1)` lookups. Removed obsolete `parseSchedules` function.

🎯 Why: These expensive operations were redundantly recalculating the exact same sorted arrays every time a component re-rendered, a filter changed, or the ETA engine ticked. This caused unnecessary CPU strain on the main thread, especially when viewing multiple lines. 

📊 Impact: Reduces time complexity of schedule lookups from `O(N log N)` to `O(1)` for repeated calls. Saves CPU cycles and eliminates memory churn across the ETA calculation and filter hooks.

🔬 Measurement: Verify by interacting with the sidebar filters and monitoring CPU profiler/render times. The `useLinhasFilter` test suite and `LineCard` components continue to function identically.

---
*PR created automatically by Jules for task [16077241059857607650](https://jules.google.com/task/16077241059857607650) started by @igormartins4*